### PR TITLE
Make OsRng available to ppoprf callers

### DIFF
--- a/ppoprf/Cargo.toml
+++ b/ppoprf/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 rand = { version = "0.8.4", default-features = false }
-rand_core = "0.6.2"
+rand_core = { version = "0.6.2", features = [ "getrandom" ] }
 rand_core_ristretto = { version="0.5.1", package="rand_core" }
 bitvec = "0.22.3"
 curve25519-dalek =  { version = "3.2.0", features = [ "serde" ] }


### PR DESCRIPTION
Enable the `getrandom` feature on the rand-core crate. While this
doesn't seem to be necessary in the context of the sta-rs repo,
direct consumers of ppoprf like a randomness server cannot build
without it.

It's possible this is a cargo bug, but I didn't investigate.