### PR TITLE
Limit github actions push triggers to the default branch.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,7 @@
 on:
   push:
+    branches:
+      - main
   pull_request:
 
 name: Tests


### PR DESCRIPTION
It was helpful to get continuous-integration feedback on all
pushes when testing, but triggering on both pull-requests and
branch pushes runs tests twice on PR branches, wasting resources
and delaying feedback. Better to only run ci when there's an
actual push to the main branch and limit tests to open pull
requests.

Experimental code can be tested by creating a 'draft' pull request.

`cargo audit` still runs on every branch push, since it's less
expensive and helpful to see failures as early as possible.