### PR TITLE
sharks: Remove obsolete documentation.

### DIFF
--- a/sharks/src/lib.rs
+++ b/sharks/src/lib.rs
@@ -28,7 +28,6 @@ impl Sharks {
   /// see the `dealer` method.
   ///
   /// Given a `secret` byte slice, returns an `Iterator` along new shares.
-  /// The maximum number of shares that can be generated is 256.
   /// A random number generator has to be provided.
   ///
   /// Example:
@@ -64,7 +63,6 @@ impl Sharks {
   }
 
   /// Given a `secret` byte slice, returns an `Iterator` along new shares.
-  /// The maximum number of shares that can be generated is 256.
   ///
   /// Example:
   /// ```


### PR DESCRIPTION
Since the field was expanded and the threshold changed from a `u8`
to a `u32`, this comment no longer applies.

Indeed, test_insufficient_shares_err recovers a secret from 500
shares, so we have unit test verification.