### PR TITLE
Update libfuzzer-sys and arbitrary deps

### DIFF
--- a/sharks/Cargo.toml
+++ b/sharks/Cargo.toml
@@ -25,7 +25,7 @@ zeroize_memory = ["zeroize"]
 [dependencies]
 rand = { version = "0.8.4", default-features = false }
 hashbrown = "0.9"
-arbitrary = { version = "0.4.7", features = ["derive"], optional = true }
+arbitrary = { version = "1.1.0", features = ["derive"], optional = true }
 zeroize = { version = "1.5.5", features = ["zeroize_derive"], optional = true }
 ff = { version = "0.10", features = ["derive"] }
 bitvec = { version = "0.22", default-features = false }

--- a/sharks/fuzz/Cargo.toml
+++ b/sharks/fuzz/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2018"
 cargo-fuzz = true
 
 [dependencies]
-libfuzzer-sys = "0.3"
-arbitrary = { version = "0.4.7", features = ["derive"] }
+libfuzzer-sys = "0.4.3"
+arbitrary = { version = "1.1.0", features = ["derive"] }
 
 [dependencies.sharks]
 path = ".."

--- a/sharks/fuzz/fuzz_targets/generate_shares.rs
+++ b/sharks/fuzz/fuzz_targets/generate_shares.rs
@@ -5,15 +5,16 @@ use arbitrary::Arbitrary;
 use sharks::{Share, Sharks};
 
 #[derive(Debug, Arbitrary)]
+// Limit threshold parameters to 16 bits so we don't immediately oom.
 struct Parameters {
-    pub threshold: u8,
+    pub threshold: u16,
     pub secret: Vec<u8>,
-    pub n_shares: usize,
+    pub n_shares: u16,
 }
 
 fuzz_target!(|params: Parameters| {
     let sharks = Sharks(params.threshold.into());
     let dealer = sharks.dealer(&params.secret);
 
-    let _shares: Vec<Share> = dealer.take(params.n_shares).collect();
+    let _shares: Vec<Share> = dealer.take(params.n_shares.into()).collect();
 });

--- a/sharks/fuzz/fuzz_targets/generate_shares.rs
+++ b/sharks/fuzz/fuzz_targets/generate_shares.rs
@@ -12,7 +12,7 @@ struct Parameters {
 }
 
 fuzz_target!(|params: Parameters| {
-    let sharks = Sharks(params.threshold);
+    let sharks = Sharks(params.threshold.into());
     let dealer = sharks.dealer(&params.secret);
 
     let _shares: Vec<Share> = dealer.take(params.n_shares).collect();

--- a/sharks/fuzz/fuzz_targets/recover.rs
+++ b/sharks/fuzz/fuzz_targets/recover.rs
@@ -5,8 +5,9 @@ use arbitrary::Arbitrary;
 use sharks::{Share, Sharks};
 
 #[derive(Debug, Arbitrary)]
+// Limit threshhold to 16 bits so we don't exhaust memory.
 struct Parameters {
-    pub threshold: u8,
+    pub threshold: u16,
     pub shares: Vec<Share>,
 }
 

--- a/sharks/fuzz/fuzz_targets/recover.rs
+++ b/sharks/fuzz/fuzz_targets/recover.rs
@@ -11,6 +11,6 @@ struct Parameters {
 }
 
 fuzz_target!(|params: Parameters| {
-    let sharks = Sharks(params.threshold);
+    let sharks = Sharks(params.threshold.into());
     let _secret = sharks.recover(&params.shares);
 });

--- a/sharks/src/lib.rs
+++ b/sharks/src/lib.rs
@@ -135,6 +135,7 @@ mod tests {
   use super::{Fp, Share, Sharks};
   use crate::ff::{Field, PrimeField};
   use alloc::{vec, vec::Vec};
+  use core::convert::TryFrom;
 
   impl Sharks {
     #[cfg(not(feature = "std"))]
@@ -240,5 +241,13 @@ mod tests {
     bytes.extend(vec![4u8; 1]);
     bytes.extend(suffix); // y coord #3
     bytes
+  }
+
+  #[test]
+  #[should_panic]
+  fn zero_threshold() {
+    let sharks = Sharks(0);
+    let testcase = Share::try_from(get_test_bytes().as_slice()).unwrap();
+    let _secret = sharks.recover(&vec![testcase]);
   }
 }


### PR DESCRIPTION
- Update to the latest versions of the fuzzer dependencies
- adapt fuzz targets to api changes

NB we have no ci coverage for the fuzzing. To test manually:
```
cd sharks
cargo +nightly fuzz build
cargo +nightly fuzz list
cargo +nightly fuzz run <deserialize_share|generate_shares|recover|serialize_share>
```

Supercedes  #53