### PR TITLE
Bump tested Rust versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        rust: [1.55.0]
+        rust: [1.58.1]
         os: [ubuntu-20.04]
 
     env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        rust: [1.58.1]
+        rust: [1.58.1, stable]
         os: [ubuntu-20.04]
 
     env:

--- a/ppoprf/src/ggm.rs
+++ b/ppoprf/src/ggm.rs
@@ -131,12 +131,11 @@ impl GGM {
   fn bit_eval(&self, bits: &BitVec, prg_inp: &[u8], output: &mut [u8]) {
     let mut eval = prg_inp.to_vec();
     for bit in bits {
-      let prg: &GGMPseudorandomGenerator;
-      if *bit {
-        prg = &self.key.prgs[1];
+      let prg: &GGMPseudorandomGenerator = if *bit {
+        &self.key.prgs[1]
       } else {
-        prg = &self.key.prgs[0];
-      }
+        &self.key.prgs[0]
+      };
       prg.eval(&eval.clone(), &mut eval);
     }
     output.copy_from_slice(&eval);

--- a/sta-rs/benches/bench.rs
+++ b/sta-rs/benches/bench.rs
@@ -61,11 +61,7 @@ fn benchmark_client_triple_generation(c: &mut Criterion) {
     let mut rnd = [0u8; 32];
     mg.sample_local_randomness(&mut rnd);
     b.iter(|| {
-      Message::generate(
-        &mg,
-        &rnd,
-        Some(AssociatedData::new(&random_bytes.to_vec())),
-      );
+      Message::generate(&mg, &rnd, Some(AssociatedData::new(&random_bytes)));
     });
   });
 
@@ -77,11 +73,7 @@ fn benchmark_client_triple_generation(c: &mut Criterion) {
     let mut rnd = [0u8; 32];
     mg.sample_oprf_randomness(ppoprf_server, &mut rnd);
     b.iter(|| {
-      Message::generate(
-        &mg,
-        &rnd,
-        Some(AssociatedData::new(&random_bytes.to_vec())),
-      );
+      Message::generate(&mg, &rnd, Some(AssociatedData::new(&random_bytes)));
     });
   });
 }
@@ -163,9 +155,7 @@ fn get_messages(params: &Params, epoch: &str) -> Vec<Message> {
 
 fn get_aux_data(do_it: bool) -> Option<AssociatedData> {
   if do_it {
-    return Some(AssociatedData::new(
-      &rand::thread_rng().gen::<[u8; 8]>().to_vec(),
-    ));
+    return Some(AssociatedData::new(&rand::thread_rng().gen::<[u8; 8]>()));
   }
   None
 }


### PR DESCRIPTION
Test on stable and 1.58.1 instead of on 1.55. Many of our dependencies now require edition 2021 support, which isn't available with our old Minimum Supported Rust Version. This is a prerequisite for merging outstanding Renovate dependency bump PRs.

Also test on stable rust, so we notice any breakage there, unlikely though it is.