### PR TITLE
sharks: Use HashSet from std.

### DIFF
--- a/sharks/Cargo.toml
+++ b/sharks/Cargo.toml
@@ -24,7 +24,6 @@ zeroize_memory = ["zeroize"]
 
 [dependencies]
 rand = { version = "0.8.4", default-features = false }
-hashbrown = "0.12"
 arbitrary = { version = "1.1.0", features = ["derive"], optional = true }
 zeroize = { version = "1.5.5", features = ["zeroize_derive"], optional = true }
 ff = { version = "0.10", features = ["derive"] }

--- a/sharks/src/lib.rs
+++ b/sharks/src/lib.rs
@@ -11,7 +11,7 @@ mod share_ff;
 
 use alloc::vec::Vec;
 use core::convert::TryInto;
-use hashbrown::HashSet;
+use std::collections::HashSet;
 
 use crate::ff::PrimeField;
 pub use share_ff::Evaluator;


### PR DESCRIPTION
Remove the external dependency to reduce the mainentance surface.
The Rust std library has used hashbrown internally since 1.36.0.

Resolves #69