### PR TITLE
Update to zipf 7.0.0.

### DIFF
--- a/sta-rs/Cargo.toml
+++ b/sta-rs/Cargo.toml
@@ -18,7 +18,7 @@ zeroize = "1.5.5"
 [dev-dependencies]
 criterion = "0.3.5"
 sta-rs-test-utils = { path = "./test-utils" }
-rand = { version = "0.8.3", features = [ "std" ] }
+rand = { version = "0.8.5", features = [ "std" ] }
 
 [features]
 star2 = ["sta-rs-test-utils/star2"]

--- a/sta-rs/Cargo.toml
+++ b/sta-rs/Cargo.toml
@@ -18,7 +18,7 @@ zeroize = "1.5.5"
 [dev-dependencies]
 criterion = "0.3.5"
 sta-rs-test-utils = { path = "./test-utils" }
-rand = { version = "0.7", default-features = false }
+rand = { version = "0.8.3", features = [ "std" ] }
 
 [features]
 star2 = ["sta-rs-test-utils/star2"]

--- a/sta-rs/test-utils/Cargo.toml
+++ b/sta-rs/test-utils/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 strobe-rs = "0.7.1"
 strobe-rng = { path = "../../strobe-rng" }
 sta-rs = { path = "../" }
-rand = { version = "0.8.3", features = [ "std" ] }
+rand = { version = "0.8.5", features = [ "std" ] }
 rand_core = "0.6.3"
 rayon = "1.5"
 zipf = "7.0.0"

--- a/sta-rs/test-utils/Cargo.toml
+++ b/sta-rs/test-utils/Cargo.toml
@@ -9,10 +9,10 @@ edition = "2018"
 strobe-rs = "0.7.1"
 strobe-rng = { path = "../../strobe-rng" }
 sta-rs = { path = "../" }
-rand = { version = "0.7", default-features = false }
+rand = { version = "0.8.3", features = [ "std" ] }
 rand_core = "0.6.3"
 rayon = "1.5"
-zipf = "6.1.0"
+zipf = "7.0.0"
 ring = "0.16.20"
 ppoprf = { path = "../../ppoprf" }
 


### PR DESCRIPTION
This requires a rand crate update as well for changes in the
Distribution trait.

Fixup for #66 