### PR TITLE
github actions: test wasm example environment

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,8 +59,13 @@ jobs:
           command: test
           args: --release
 
-      - name: WASM
+      - name: WASM pkg
         run: |
           curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
           cd ./star-wasm
           make build
+
+      - name: WASM www
+        run: |
+          cd ./star-wasm/www
+          make


### PR DESCRIPTION
Add continuous integration coverage of the star-wasm/www code,
which provides a test environment for the client package.

Since dependency audits see the package.json in this directory,
it's helpful to have corresponding confirmation that proposed
changes don't break the build.

Resolves https://github.com/brave/sta-rs/issues/75