### PR TITLE
Exclude patch version from serde dependency

### DIFF
--- a/ppoprf/Cargo.toml
+++ b/ppoprf/Cargo.toml
@@ -13,7 +13,7 @@ rand_core_ristretto = { version="0.5.1", package="rand_core" }
 bitvec = "1.0.0"
 curve25519-dalek =  { version = "3.2.0", features = [ "serde" ] }
 criterion = "0.3.5"
-serde = "1.0.137"
+serde = "1.0"
 strobe-rs = "0.7.1"
 strobe-rng = { path = "../strobe-rng" }
 base64 = "0.13"


### PR DESCRIPTION
The `adblock-ffi` crate in the browser uses 1.0.137, which causes a version conflict error during the build.

Removing the patch version so that Cargo can resolve a common version without any error.