### PR TITLE
Remove unused ring crate.

### DIFF
--- a/sta-rs/Cargo.toml
+++ b/sta-rs/Cargo.toml
@@ -11,7 +11,6 @@ strobe-rs = "0.7.1"
 strobe-rng = { path = "../strobe-rng" }
 adss-rs = { path = "../adss-rs" }
 ppoprf = { path = "../ppoprf" }
-ring = "0.16.20"
 rand_core = "0.6.3"
 zeroize = "1.5.7"
 

--- a/sta-rs/test-utils/Cargo.toml
+++ b/sta-rs/test-utils/Cargo.toml
@@ -13,7 +13,6 @@ rand = { version = "0.8.5", features = [ "std" ] }
 rand_core = "0.6.3"
 rayon = "1.5"
 zipf = "7.0.0"
-ring = "0.16.20"
 ppoprf = { path = "../../ppoprf" }
 
 [features]


### PR DESCRIPTION
This isn't used in the code and is expensive to build.