### PR TITLE
Derive Eq along with PartialEq.

### DIFF
--- a/ppoprf/src/ppoprf.rs
+++ b/ppoprf/src/ppoprf.rs
@@ -155,7 +155,7 @@ pub struct Evaluation {
 
 // Public wrapper for points associated with the elliptic curve that
 // is used
-#[derive(Deserialize, Serialize, Clone, Debug, PartialEq)]
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
 pub struct Point(CompressedRistretto);
 impl Point {
   fn decompress(&self) -> Option<RistrettoPoint> {

--- a/sta-rs/src/lib.rs
+++ b/sta-rs/src/lib.rs
@@ -129,7 +129,7 @@ pub const DEBUG: bool = false;
 // server-side. Measurements are only revealed on the server-side if the
 // `threshold` is met, in terms of clients that send the same
 // `Measurement` value.
-#[derive(Clone, Debug, PartialEq, Zeroize, ZeroizeOnDrop)]
+#[derive(Clone, Debug, PartialEq, Eq, Zeroize, ZeroizeOnDrop)]
 pub struct SingleMeasurement(Vec<u8>);
 impl SingleMeasurement {
   pub fn new(x: &[u8]) -> Self {


### PR DESCRIPTION
clippy warns about this as of rust 1.63.0, making the point that
if a structs members can all derive full `Eq` that it's an unecessary
limitation to only derive `PartialEq`. Best to conform to style.

Fixes clippy issue in github ci.