### PR TITLE
ppoprf: switch to dotenvy

### DIFF
--- a/ppoprf/Cargo.toml
+++ b/ppoprf/Cargo.toml
@@ -27,7 +27,7 @@ criterion = "0.3.6"
 env_logger = "0.9.0"
 log = "0.4.17"
 reqwest = { version = "0.11.11", features = [ "blocking", "json" ] }
-dotenv = "0.15"
+dotenvy = "0.15.3"
 insta = "1.18.2"
 matches = "0.1.9"
 

--- a/ppoprf/examples/server.rs
+++ b/ppoprf/examples/server.rs
@@ -27,7 +27,7 @@ use actix_web::middleware::Logger;
 use actix_web::{
   error::ResponseError, get, http::StatusCode, post, web, HttpResponse,
 };
-use dotenv::dotenv;
+use dotenvy::dotenv;
 use env_logger::Env;
 use log::{info, warn};
 


### PR DESCRIPTION
Replace the unmaintained `dotenv` crate with the `dotenvy` fork.
This is used to read environment variable from a `.env` file to
simplify testing configuration in the example randomness server.

https://rustsec.org/advisories/RUSTSEC-2021-0141.html

Resolves #111