### PR TITLE
ppoprf: remove dotenvy

### DIFF
--- a/ppoprf/Cargo.toml
+++ b/ppoprf/Cargo.toml
@@ -26,7 +26,6 @@ criterion = "0.4.0"
 env_logger = "0.9.0"
 log = "0.4.17"
 reqwest = { version = "0.11.11", features = [ "blocking", "json" ] }
-dotenvy = "0.15.3"
 insta = "1.19.1"
 matches = "0.1.9"
 tokio = { version = "1.21.1", features = ["macros", "rt-multi-thread", "time"] }

--- a/ppoprf/examples/server.rs
+++ b/ppoprf/examples/server.rs
@@ -26,7 +26,6 @@
 //!       ]}'
 //! ```
 
-use dotenvy::dotenv;
 use env_logger::Env;
 use log::{info, warn};
 use serde::{Deserialize, Serialize};
@@ -124,8 +123,6 @@ async fn eval(
 
 #[tokio::main]
 async fn main() {
-  dotenv().ok();
-
   let host = "localhost";
   let port = 8080;
 


### PR DESCRIPTION
This was used in the example ppoprf randomness server to simplify configuration for testing. The latest release requires a newer rust release than our mimimum-supported version and is breaking integration tests.

Since it's not essential remove it for now. It can be restored if we can agree on a compatible support floor with upstream. In the meantime, configuration variables must be set directly in the environment.