### PR TITLE
ppoprf: Update dotenvy to 0.15.5.

### DIFF
--- a/ppoprf/Cargo.toml
+++ b/ppoprf/Cargo.toml
@@ -26,7 +26,7 @@ criterion = "0.4.0"
 env_logger = "0.9.0"
 log = "0.4.17"
 reqwest = { version = "0.11.11", features = [ "blocking", "json" ] }
-dotenvy = "0.15.3"
+dotenvy = "0.15.5"
 insta = "1.19.1"
 matches = "0.1.9"
 tokio = { version = "1.21.1", features = ["macros", "rt-multi-thread", "time"] }


### PR DESCRIPTION
Bump the minimum version past 0.15.4 which requires a newer Rust release than our minimum-supported version.

Upstream was responsive to our issue, so this is a better resolution to the broke tests than removing the crate.