### PR TITLE
Choose Sophie Germain prime (2^128 + 12451)

### DIFF
--- a/sharks/src/share_ff.rs
+++ b/sharks/src/share_ff.rs
@@ -14,7 +14,8 @@ pub const FIELD_ELEMENT_LEN: usize = 24;
 #[cfg_attr(feature = "fuzzing", derive(Arbitrary))]
 #[cfg_attr(feature = "zeroize_memory", derive(Zeroize))]
 #[derive(PrimeField)]
-#[PrimeFieldModulus = "340282366920938463463374607431768223907"] // 2^128 + 12451 (https://eprint.iacr.org/2011/326)
+// 2^128 + 12451 (https://eprint.iacr.org/2011/326)
+#[PrimeFieldModulus = "340282366920938463463374607431768223907"]
 #[PrimeFieldGenerator = "3"]
 #[PrimeFieldReprEndianness = "little"]
 pub struct Fp([u64; 3]);
@@ -225,7 +226,6 @@ mod tests {
     let iter =
       get_evaluator(vec![vec![fp_three(), fp_two(), fp_three() + fp_two()]]);
     let values: Vec<(Fp, Vec<Fp>)> = iter.take(2).map(|s| (s.x, s.y)).collect();
-    println!("values: {:?}", values[1].1[0].0);
     assert_eq!(
       values,
       vec![

--- a/sharks/src/share_ff.rs
+++ b/sharks/src/share_ff.rs
@@ -14,7 +14,7 @@ pub const FIELD_ELEMENT_LEN: usize = 24;
 #[cfg_attr(feature = "fuzzing", derive(Arbitrary))]
 #[cfg_attr(feature = "zeroize_memory", derive(Zeroize))]
 #[derive(PrimeField)]
-#[PrimeFieldModulus = "680564733841876926926749214863536421547"] // 2^129 - 1365
+#[PrimeFieldModulus = "340282366920938463463374607431768223907"] // 2^128 + 12451 (https://eprint.iacr.org/2011/326)
 #[PrimeFieldGenerator = "3"]
 #[PrimeFieldReprEndianness = "little"]
 pub struct Fp([u64; 3]);
@@ -225,11 +225,12 @@ mod tests {
     let iter =
       get_evaluator(vec![vec![fp_three(), fp_two(), fp_three() + fp_two()]]);
     let values: Vec<(Fp, Vec<Fp>)> = iter.take(2).map(|s| (s.x, s.y)).collect();
+    println!("values: {:?}", values[1].1[0].0);
     assert_eq!(
       values,
       vec![
-        (fp_one(), vec![Fp([0u64, 6825, 0,])]),
-        (fp_two(), vec![Fp([9223372036854775808u64, 14332, 0,])])
+        (fp_one(), vec![Fp([12451u64, 18446744073709427106, 0])]),
+        (fp_two(), vec![Fp([12451u64, 18446744073709290145, 0])])
       ]
     );
   }


### PR DESCRIPTION
- Previous prime was randomly chosen
- This prime has been used in the past: https://eprint.iacr.org/2011/326
- It's smaller than the previous prime (closer to 2^128 than to 2^129)
- While safety of prime field is not required here, it is recommended to align with previously-used primes where possible
- Sophie Germain primes are widely regarded as being "safe": https://en.wikipedia.org/wiki/Safe_and_Sophie_Germain_primes