### PR TITLE
Fuzzing-related code cleanups

### DIFF
--- a/sharks/benches/benchmarks.rs
+++ b/sharks/benches/benchmarks.rs
@@ -5,17 +5,18 @@ use sharks::{Share, Sharks};
 
 fn dealer(c: &mut Criterion) {
   let sharks = Sharks(255);
-  let mut dealer = sharks.dealer(&[1]);
+  let mut dealer = sharks.dealer(&[1]).unwrap();
 
   c.bench_function("obtain_shares_dealer", |b| {
-    b.iter(|| sharks.dealer(black_box(&[1])))
+    b.iter(|| sharks.dealer(black_box(&[1])).unwrap())
   });
   c.bench_function("step_shares_dealer", |b| b.iter(|| dealer.next()));
 }
 
 fn recover(c: &mut Criterion) {
   let sharks = Sharks(255);
-  let shares: Vec<Share> = sharks.dealer(&[1]).take(255).collect();
+  let dealer = sharks.dealer(&[1]).unwrap();
+  let shares: Vec<Share> = dealer.take(255).collect();
 
   c.bench_function("recover_secret", |b| {
     b.iter(|| sharks.recover(black_box(shares.as_slice())))

--- a/sharks/fuzz/fuzz_targets/generate_shares.rs
+++ b/sharks/fuzz/fuzz_targets/generate_shares.rs
@@ -14,7 +14,7 @@ struct Parameters {
 
 fuzz_target!(|params: Parameters| {
     let sharks = Sharks(params.threshold.into());
-    let dealer = sharks.dealer(&params.secret);
-
-    let _shares: Vec<Share> = dealer.take(params.n_shares.into()).collect();
+    if let Ok(dealer) = sharks.dealer(&params.secret) {
+        let _shares: Vec<Share> = dealer.take(params.n_shares.into()).collect();
+    }
 });

--- a/sharks/src/lib.rs
+++ b/sharks/src/lib.rs
@@ -123,7 +123,7 @@ impl Sharks {
       Err("Not enough shares to recover original secret")
     } else {
       // We only need the threshold number of shares to recover
-      Ok(interpolate(&values[0..self.0 as usize]))
+      interpolate(&values[0..self.0 as usize])
     }
   }
 }
@@ -243,10 +243,10 @@ mod tests {
   }
 
   #[test]
-  #[should_panic]
   fn zero_threshold() {
     let sharks = Sharks(0);
     let testcase = Share::try_from(get_test_bytes().as_slice()).unwrap();
-    let _secret = sharks.recover(&vec![testcase]);
+    let secret = sharks.recover(&vec![testcase]);
+    assert!(secret.is_err());
   }
 }

--- a/sharks/src/lib.rs
+++ b/sharks/src/lib.rs
@@ -37,7 +37,7 @@ impl Sharks {
   /// # let sharks = Sharks(3);
   /// // Obtain an iterator over the shares for secret [1, 2]
   /// let mut rng = rand_chacha::ChaCha8Rng::from_seed([0x90; 32]);
-  /// let dealer = sharks.dealer_rng(&[1, 2], &mut rng);
+  /// let dealer = sharks.dealer_rng(&[1, 2], &mut rng).unwrap();
   /// // Get 3 shares
   /// let shares: Vec<Share> = dealer.take(3).collect();
   pub fn dealer_rng<R: rand::Rng>(
@@ -45,7 +45,7 @@ impl Sharks {
     secret: &[u8],
     rng: &mut R,
     //) -> impl Iterator<Item = Share> {
-  ) -> Evaluator {
+  ) -> Result<Evaluator, &str> {
     let mut polys = Vec::with_capacity(secret.len());
 
     let secret_fp_len = secret.len() / FIELD_ELEMENT_LEN;
@@ -54,12 +54,15 @@ impl Sharks {
         secret[i * FIELD_ELEMENT_LEN..(i + 1) * FIELD_ELEMENT_LEN]
           .try_into()
           .expect("bad chunk"),
-      ))
-      .unwrap();
+      ));
+      if element.is_none().into() {
+          return Err("Failed to create field element from secret");
+      }
+      let element = element.unwrap();
       polys.push(random_polynomial(element, self.0, rng));
     }
 
-    get_evaluator(polys)
+    Ok(get_evaluator(polys))
   }
 
   /// Given a `secret` byte slice, returns an `Iterator` along new shares.
@@ -69,11 +72,11 @@ impl Sharks {
   /// # use sharks::{ Sharks, Share };
   /// # let sharks = Sharks(3);
   /// // Obtain an iterator over the shares for secret [1, 2]
-  /// let dealer = sharks.dealer(&[1, 2]);
+  /// let dealer = sharks.dealer(&[1, 2]).unwrap();
   /// // Get 3 shares
   /// let shares: Vec<Share> = dealer.take(3).collect();
   #[cfg(feature = "std")]
-  pub fn dealer(&self, secret: &[u8]) -> Evaluator {
+  pub fn dealer(&self, secret: &[u8]) -> Result<Evaluator, &str> {
     let mut rng = rand::thread_rng();
     self.dealer_rng(secret, &mut rng)
   }
@@ -88,7 +91,8 @@ impl Sharks {
   /// # use rand_chacha::rand_core::SeedableRng;
   /// # let sharks = Sharks(3);
   /// # let mut rng = rand_chacha::ChaCha8Rng::from_seed([0x90; 32]);
-  /// # let mut shares: Vec<Share> = sharks.dealer_rng(&[1], &mut rng).take(3).collect();
+  /// # let dealer = sharks.dealer_rng(&[1], &mut rng).unwrap();
+  /// # let mut shares: Vec<Share> = dealer.take(3).collect();
   /// // Recover original secret from shares
   /// let secret = sharks.recover(&shares);
   /// // Secret correctly recovered
@@ -146,7 +150,7 @@ mod tests {
     }
 
     #[cfg(feature = "std")]
-    fn make_shares(&self, secret: &[u8]) -> impl Iterator<Item = Share> {
+    fn make_shares(&self, secret: &[u8]) -> Result<impl Iterator<Item = Share>, &str> {
       self.dealer(secret)
     }
   }
@@ -179,7 +183,7 @@ mod tests {
   fn test_insufficient_shares_err() {
     let sharks = Sharks(500);
     let shares: Vec<Share> =
-      sharks.make_shares(&fp_one_repr()).take(499).collect();
+      sharks.make_shares(&fp_one_repr()).unwrap().take(499).collect();
     let secret = sharks.recover(&shares);
     assert!(secret.is_err());
   }
@@ -188,7 +192,7 @@ mod tests {
   fn test_duplicate_shares_err() {
     let sharks = Sharks(500);
     let mut shares: Vec<Share> =
-      sharks.make_shares(&fp_one_repr()).take(500).collect();
+      sharks.make_shares(&fp_one_repr()).unwrap().take(500).collect();
     shares[1] = Share {
       x: shares[0].x,
       y: shares[0].y.clone(),
@@ -205,7 +209,7 @@ mod tests {
     input.extend(fp_two_repr());
     input.extend(fp_three_repr());
     input.extend(fp_four_repr());
-    let shares: Vec<Share> = sharks.make_shares(&input).take(500).collect();
+    let shares: Vec<Share> = sharks.make_shares(&input).unwrap().take(500).collect();
     let secret = sharks.recover(&shares).unwrap();
     assert_eq!(secret, get_test_bytes());
   }
@@ -220,11 +224,11 @@ mod tests {
     input.extend(fp_two_repr());
     input.extend(fp_three_repr());
     input.extend(fp_four_repr());
-    let evaluator = sharks.dealer(&input);
+    let evaluator = sharks.dealer(&input).unwrap();
     let shares: Vec<Share> = iter::repeat_with(|| evaluator.gen(&mut rng))
       .take(55)
       .collect();
-    //let shares: Vec<Share> = sharks.make_shares(&[1, 2, 3, 4]).take(255).collect();
+    //let shares: Vec<Share> = sharks.make_shares(&[1, 2, 3, 4]).unwrap().take(255).collect();
     let secret = sharks.recover(&shares).unwrap();
     assert_eq!(secret, get_test_bytes());
   }
@@ -248,5 +252,18 @@ mod tests {
     let testcase = Share::try_from(get_test_bytes().as_slice()).unwrap();
     let secret = sharks.recover(&vec![testcase]);
     assert!(secret.is_err());
+  }
+
+  #[test]
+  fn dealer_short_secret() {
+      let sharks = Sharks(2);
+
+      // one less byte than needed
+      let secret = [0u8; FIELD_ELEMENT_LEN - 1];
+      let _dealer = sharks.dealer(&secret);
+
+      // one more for a short second element
+      let secret = [1u8; FIELD_ELEMENT_LEN + 1];
+      let _dealer = sharks.dealer(&secret);
   }
 }

--- a/sharks/src/lib.rs
+++ b/sharks/src/lib.rs
@@ -56,7 +56,7 @@ impl Sharks {
           .expect("bad chunk"),
       ));
       if element.is_none().into() {
-          return Err("Failed to create field element from secret");
+        return Err("Failed to create field element from secret");
       }
       let element = element.unwrap();
       polys.push(random_polynomial(element, self.0, rng));
@@ -150,7 +150,10 @@ mod tests {
     }
 
     #[cfg(feature = "std")]
-    fn make_shares(&self, secret: &[u8]) -> Result<impl Iterator<Item = Share>, &str> {
+    fn make_shares(
+      &self,
+      secret: &[u8],
+    ) -> Result<impl Iterator<Item = Share>, &str> {
       self.dealer(secret)
     }
   }
@@ -182,8 +185,11 @@ mod tests {
   #[test]
   fn test_insufficient_shares_err() {
     let sharks = Sharks(500);
-    let shares: Vec<Share> =
-      sharks.make_shares(&fp_one_repr()).unwrap().take(499).collect();
+    let shares: Vec<Share> = sharks
+      .make_shares(&fp_one_repr())
+      .unwrap()
+      .take(499)
+      .collect();
     let secret = sharks.recover(&shares);
     assert!(secret.is_err());
   }
@@ -191,8 +197,11 @@ mod tests {
   #[test]
   fn test_duplicate_shares_err() {
     let sharks = Sharks(500);
-    let mut shares: Vec<Share> =
-      sharks.make_shares(&fp_one_repr()).unwrap().take(500).collect();
+    let mut shares: Vec<Share> = sharks
+      .make_shares(&fp_one_repr())
+      .unwrap()
+      .take(500)
+      .collect();
     shares[1] = Share {
       x: shares[0].x,
       y: shares[0].y.clone(),
@@ -209,7 +218,8 @@ mod tests {
     input.extend(fp_two_repr());
     input.extend(fp_three_repr());
     input.extend(fp_four_repr());
-    let shares: Vec<Share> = sharks.make_shares(&input).unwrap().take(500).collect();
+    let shares: Vec<Share> =
+      sharks.make_shares(&input).unwrap().take(500).collect();
     let secret = sharks.recover(&shares).unwrap();
     assert_eq!(secret, get_test_bytes());
   }
@@ -256,14 +266,14 @@ mod tests {
 
   #[test]
   fn dealer_short_secret() {
-      let sharks = Sharks(2);
+    let sharks = Sharks(2);
 
-      // one less byte than needed
-      let secret = [0u8; FIELD_ELEMENT_LEN - 1];
-      let _dealer = sharks.dealer(&secret);
+    // one less byte than needed
+    let secret = [0u8; FIELD_ELEMENT_LEN - 1];
+    let _dealer = sharks.dealer(&secret);
 
-      // one more for a short second element
-      let secret = [1u8; FIELD_ELEMENT_LEN + 1];
-      let _dealer = sharks.dealer(&secret);
+    // one more for a short second element
+    let secret = [1u8; FIELD_ELEMENT_LEN + 1];
+    let _dealer = sharks.dealer(&secret);
   }
 }

--- a/sharks/src/share_ff.rs
+++ b/sharks/src/share_ff.rs
@@ -151,8 +151,8 @@ impl core::convert::TryFrom<&[u8]> for Share {
   type Error = &'static str;
 
   fn try_from(s: &[u8]) -> Result<Share, Self::Error> {
-    if s.len() < 2 {
-      Err("A Share must be at least 2 bytes long")
+    if s.len() < FIELD_ELEMENT_LEN {
+      Err("A Share must have enough bytes to represent a field element")
     } else {
       let x = Fp::from_repr(FpRepr(
         s[..FIELD_ELEMENT_LEN]
@@ -265,6 +265,13 @@ mod tests {
     let share = Share::try_from(&get_test_bytes()[..]).unwrap();
     assert_eq!(share.x, fp_one());
     assert_eq!(share.y, vec![fp_two(), fp_three()]);
+  }
+
+  #[test]
+  fn share_from_short_u8_slice_fails() {
+    let bytes = get_test_bytes();
+    assert!(Share::try_from(&bytes[0..FIELD_ELEMENT_LEN - 1]).is_err());
+    assert!(Share::try_from(&bytes[0..1]).is_err());
   }
 
   fn get_test_bytes() -> Vec<u8> {

--- a/sharks/src/share_ff.rs
+++ b/sharks/src/share_ff.rs
@@ -55,9 +55,11 @@ pub fn interpolate(shares: &[Share]) -> Result<Vec<u8>, &'static str> {
       Vec::from(e) // turn into byte vector
     })
     .collect();
-  Ok(res
-    .iter()
-    .fold(Vec::new(), |acc, r| [acc, r.to_vec()].concat()))
+  Ok(
+    res
+      .iter()
+      .fold(Vec::new(), |acc, r| [acc, r.to_vec()].concat()),
+  )
 }
 
 // Generates `k` polynomial coefficients, being the last one `s` and the
@@ -160,7 +162,7 @@ impl core::convert::TryFrom<&[u8]> for Share {
           .expect("Failed to parse bytes for x coordinate"),
       ));
       if x.is_none().into() {
-          return Err("Failed to create field element from x representation");
+        return Err("Failed to create field element from x representation");
       }
       let x = x.unwrap();
       let y_coords_bytes = s[FIELD_ELEMENT_LEN..].to_vec();
@@ -168,9 +170,9 @@ impl core::convert::TryFrom<&[u8]> for Share {
       let mut y = Vec::with_capacity(total_y_coords_len / FIELD_ELEMENT_LEN);
       for i in 0..total_y_coords_len / FIELD_ELEMENT_LEN {
         let f = Fp::from_repr(FpRepr(
-            y_coords_bytes[i * FIELD_ELEMENT_LEN..(i + 1) * FIELD_ELEMENT_LEN]
-              .try_into()
-              .expect("Failed to parse bytes for y coordinates"),
+          y_coords_bytes[i * FIELD_ELEMENT_LEN..(i + 1) * FIELD_ELEMENT_LEN]
+            .try_into()
+            .expect("Failed to parse bytes for y coordinates"),
         ));
         if f.is_none().into() {
           return Err("Failed to create field element from y representation");
@@ -291,7 +293,10 @@ mod tests {
 
   #[test]
   fn bad_share_bytes() {
-      let bytes: Vec<u8> = vec![10u8, 39, 39, 39, 39, 39, 39, 39, 39, 39, 39, 39, 10, 0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 0, 0];
-      let _ = Share::try_from(bytes.as_slice());
+    let bytes: Vec<u8> = vec![
+      10u8, 39, 39, 39, 39, 39, 39, 39, 39, 39, 39, 39, 10, 0, 0, 0, 0, 0, 0,
+      10, 0, 0, 0, 0, 0,
+    ];
+    let _ = Share::try_from(bytes.as_slice());
   }
 }

--- a/sharks/src/share_ff.rs
+++ b/sharks/src/share_ff.rs
@@ -36,7 +36,7 @@ impl From<Fp> for Vec<u64> {
 // Where each (key, value) pair corresponds to one share, where the key is the `x` and the value is a vector of `y`,
 // where each element corresponds to one of the secret's byte chunks.
 pub fn interpolate(shares: &[Share]) -> Result<Vec<u8>, &'static str> {
-  if shares.len() < 1 {
+  if shares.is_empty() {
     return Err("Need at least one share to interpolate");
   }
   let res: Vec<Vec<u8>> = (0..shares[0].y.len())

--- a/sta-rs/benches/bench.rs
+++ b/sta-rs/benches/bench.rs
@@ -39,9 +39,7 @@ fn benchmark_client_triple_generation(c: &mut Criterion) {
     let mg = client_zipf(10000, 1.03, 2, "t");
     let mut rnd = [0u8; 32];
     mg.sample_local_randomness(&mut rnd);
-    b.iter(|| {
-      Message::generate(&mg, &rnd, None);
-    });
+    b.iter(|| Message::generate(&mg, &rnd, None).unwrap());
   });
 
   #[cfg(feature = "star2")]
@@ -51,7 +49,7 @@ fn benchmark_client_triple_generation(c: &mut Criterion) {
     let mut rnd = [0u8; 32];
     mg.sample_oprf_randomness(ppoprf_server, &mut rnd);
     b.iter(|| {
-      Message::generate(&mg, &rnd, None);
+      Message::generate(&mg, &rnd, None).unwrap();
     });
   });
 
@@ -61,7 +59,8 @@ fn benchmark_client_triple_generation(c: &mut Criterion) {
     let mut rnd = [0u8; 32];
     mg.sample_local_randomness(&mut rnd);
     b.iter(|| {
-      Message::generate(&mg, &rnd, Some(AssociatedData::new(&random_bytes)));
+      Message::generate(&mg, &rnd, Some(AssociatedData::new(&random_bytes)))
+        .unwrap();
     });
   });
 
@@ -73,7 +72,8 @@ fn benchmark_client_triple_generation(c: &mut Criterion) {
     let mut rnd = [0u8; 32];
     mg.sample_oprf_randomness(ppoprf_server, &mut rnd);
     b.iter(|| {
-      Message::generate(&mg, &rnd, Some(AssociatedData::new(&random_bytes)));
+      Message::generate(&mg, &rnd, Some(AssociatedData::new(&random_bytes)))
+        .unwrap();
     });
   });
 }
@@ -83,7 +83,7 @@ fn benchmark_server_retrieval(c: &mut Criterion) {
   let mut rnd = [0u8; 32];
   mg.sample_local_randomness(&mut rnd);
   let messages: Vec<Message> =
-    iter::repeat_with(|| Message::generate(&mg, &rnd, None))
+    iter::repeat_with(|| Message::generate(&mg, &rnd, None).unwrap())
       .take(1000)
       .collect();
   c.bench_function("Server retrieve outputs", |b| {
@@ -130,7 +130,7 @@ fn get_messages(params: &Params, epoch: &str) -> Vec<Message> {
   let mut rnd = [0u8; 32];
   if params.local {
     iter::repeat_with(|| {
-      Message::generate(&mg, &rnd, get_aux_data(params.aux_data))
+      Message::generate(&mg, &rnd, get_aux_data(params.aux_data)).unwrap()
     })
     .take(params.clients)
     .collect()
@@ -143,7 +143,7 @@ fn get_messages(params: &Params, epoch: &str) -> Vec<Message> {
       let mut ppoprf_server = PPOPRFServer::new(&[b"t".to_vec()]);
       let messages = iter::repeat_with(|| {
         sample_oprf_randomness(&ppoprf_server, &mut rnd);
-        Message::generate(&mg, &rnd, get_aux_data(params.aux_data))
+        Message::generate(&mg, &rnd, get_aux_data(params.aux_data)).unwrap()
       })
       .take(params.clients)
       .collect();

--- a/sta-rs/tests/e2e.rs
+++ b/sta-rs/tests/e2e.rs
@@ -13,7 +13,8 @@ fn serialize_ciphertext() {
   let mg = MessageGenerator::new(SingleMeasurement::new(b"foobar"), 0, "epoch");
   let mut rnd = [0u8; 32];
   mg.sample_local_randomness(&mut rnd);
-  let triple = Message::generate(&mg, &rnd, None);
+  let triple = Message::generate(&mg, &rnd, None)
+    .expect("Failed to generate message triplet");
   let bytes = triple.ciphertext.to_bytes();
   assert_eq!(Ciphertext::from_bytes(&bytes), triple.ciphertext);
 }
@@ -23,7 +24,8 @@ fn serialize_triple() {
   let mg = MessageGenerator::new(SingleMeasurement::new(b"foobar"), 0, "epoch");
   let mut rnd = [0u8; 32];
   mg.sample_local_randomness(&mut rnd);
-  let triple = Message::generate(&mg, &rnd, None);
+  let triple = Message::generate(&mg, &rnd, None)
+    .expect("Failed to generate message triplet");
   let bytes = triple.to_bytes();
   assert_eq!(Message::from_bytes(&bytes), Some(triple));
 }
@@ -33,7 +35,8 @@ fn roundtrip() {
   let mg = MessageGenerator::new(SingleMeasurement::new(b"foobar"), 1, "epoch");
   let mut rnd = [0u8; 32];
   mg.sample_local_randomness(&mut rnd);
-  let triple = Message::generate(&mg, &rnd, None);
+  let triple = Message::generate(&mg, &rnd, None)
+    .expect("Failed to generate message triplet");
 
   let commune = share_recover(&[triple.share]).unwrap();
   let message = commune.get_message();
@@ -141,7 +144,7 @@ fn star_no_aux_multiple_block(oprf_server: Option<PPOPRFServer>) {
         #[cfg(feature = "star2")]
         mg.sample_oprf_randomness(oprf_server, &mut rnd);
       }
-      Message::generate(&mg, &rnd, None)
+      Message::generate(&mg, &rnd, None).unwrap()
     })
     .collect();
   let outputs = agg_server.retrieve_outputs(&messages[..]);
@@ -203,6 +206,7 @@ fn star_no_aux_single_block(oprf_server: Option<PPOPRFServer>) {
         mg.sample_oprf_randomness(oprf_server, &mut rnd);
       }
       Message::generate(&mg, &rnd, None)
+        .expect("Failed to generate message triplet")
     })
     .collect();
   let outputs = agg_server.retrieve_outputs(&messages);
@@ -266,6 +270,7 @@ fn star_with_aux_multiple_block(oprf_server: Option<PPOPRFServer>) {
       }
       counter += 1;
       Message::generate(&mg, &rnd, Some(AssociatedData::new(&[counter; 1])))
+        .unwrap()
     })
     .collect();
   let outputs = agg_server.retrieve_outputs(&messages[..]);
@@ -325,6 +330,7 @@ fn star_rand_with_aux_multiple_block(oprf_server: Option<PPOPRFServer>) {
       }
       counter += 1;
       Message::generate(&mg, &rnd, Some(AssociatedData::new(&[counter; 4])))
+        .unwrap()
     })
     .collect();
   let outputs = agg_server.retrieve_outputs(&messages[..]);

--- a/star-wasm/src/lib.rs
+++ b/star-wasm/src/lib.rs
@@ -41,8 +41,11 @@ pub fn create_share(measurement: &[u8], threshold: u32, epoch: &str) -> String {
     threshold,
     epoch,
   );
-  let WASMSharingMaterial { key, share, tag } =
-    mg.share_with_local_randomness();
+  let share_result = mg.share_with_local_randomness();
+  if share_result.is_err() {
+    return "".to_owned();
+  }
+  let WASMSharingMaterial { key, share, tag } = share_result.unwrap();
 
   let key_b64 = encode(&key);
   let share_b64 = encode(&share.to_bytes());


### PR DESCRIPTION
Fixing various issues to allow `cargo fuzz` to run usefully on the sharks crate.

Status of the various targets; they should not immediately exit with a test case:

- [x] generate_shares
- [x] serialize_share (already working on `main`)
- [x] deserialize_share
- [x] recover

Tested with `cargo +nightly fuzz run $target`
