### PR TITLE
sharks: Update benchmark to new field size

### DIFF
--- a/sharks/benches/benchmarks.rs
+++ b/sharks/benches/benchmarks.rs
@@ -37,7 +37,7 @@ fn share(c: &mut Criterion) {
 }
 
 fn get_test_bytes() -> Vec<u8> {
-  let suffix = vec![0u8; 31];
+  let suffix = vec![0u8; sharks::FIELD_ELEMENT_LEN - 1];
   let mut bytes = vec![1u8; 1];
   bytes.extend(suffix.clone()); // x coord
   bytes.extend(vec![2u8; 1]);


### PR DESCRIPTION
When we switched to a smaller field size, the `cargo bench` target wasn't updated to match, causing assertion failures. This imports the field length constant from the target crate to generate test input of the correct length.