### PR TITLE
Update MSRV to 1.59.0.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        rust: [1.58.1, stable]
+        rust: [1.59.0, stable]
         os: [ubuntu-20.04]
 
     env:


### PR DESCRIPTION
Bump minimum supported rust version to build with scoped-tls v1.0.1, which is a dependency of both wasm-bindgen-test and the warp web framework used by the ppoprf example server.

We're trying to stay compatible with the Brave browser. Fortunately it also recently bumped to 1.59.0.

This should resolve the ci build failures we're seeing this week with e.g. #154.