### PR TITLE
star-wasm: Remove unnecessary borrow

### DIFF
--- a/star-wasm/src/lib.rs
+++ b/star-wasm/src/lib.rs
@@ -44,9 +44,9 @@ pub fn create_share(measurement: &[u8], threshold: u32, epoch: &str) -> String {
   let WASMSharingMaterial { key, share, tag } =
     mg.share_with_local_randomness();
 
-  let key_b64 = encode(&key);
+  let key_b64 = encode(key);
   let share_b64 = encode(&share.to_bytes());
-  let tag_b64 = encode(&tag);
+  let tag_b64 = encode(tag);
 
   format!(
     r#"{{"key": "{}", "share": "{}", "tag": "{}"}}"#,


### PR DESCRIPTION
Address clippy::needless_borrow warning with rust 1.65.0. `base64::encode` takes an `AsRef<[u8]>` so passing an array will automatically borrow without needing an explicit sigal.

This should unblock other PRs with the latest CI issue,