### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @brave/star-reviewers


### PR DESCRIPTION
Point github responsibility and review at the related team within the brave organisation, to simplify access control maintenance.

Current members are:
- @rillian
- @alxdavids 
- @claucece
- @ankeleralph
- @evq