### PR TITLE
Fix a couple of lints

### DIFF
--- a/sta-rs/src/lib.rs
+++ b/sta-rs/src/lib.rs
@@ -319,12 +319,12 @@ impl Message {
     // ciphertext: Ciphertext
     let cb = load_bytes(slice)?;
     let ciphertext = Ciphertext::from_bytes(cb);
-    slice = &slice[4 + cb.len() as usize..];
+    slice = &slice[4 + cb.len()..];
 
     // share: Share
     let sb = load_bytes(slice)?;
     let share = Share::from_bytes(sb)?;
-    slice = &slice[4 + sb.len() as usize..];
+    slice = &slice[4 + sb.len()..];
 
     // tag: Vec<u8>
     let tag = load_bytes(slice)?;

--- a/sta-rs/test-utils/src/lib.rs
+++ b/sta-rs/test-utils/src/lib.rs
@@ -102,7 +102,7 @@ impl AggregationServer {
         let mut slice = &p[..];
 
         let measurement_bytes = load_bytes(slice).unwrap();
-        slice = &slice[4 + measurement_bytes.len() as usize..];
+        slice = &slice[4 + measurement_bytes.len()..];
         if !slice.is_empty() {
           let aux_bytes = load_bytes(slice).unwrap();
           if !aux_bytes.is_empty() {

--- a/sta-rs/tests/e2e.rs
+++ b/sta-rs/tests/e2e.rs
@@ -47,7 +47,7 @@ fn roundtrip() {
   let mut slice = &plaintext[..];
 
   let measurement_bytes = load_bytes(slice).unwrap();
-  slice = &slice[4 + measurement_bytes.len() as usize..];
+  slice = &slice[4 + measurement_bytes.len()..];
 
   if !slice.is_empty() {
     let aux_bytes = load_bytes(slice).unwrap();

--- a/star-wasm/src/lib.rs
+++ b/star-wasm/src/lib.rs
@@ -48,7 +48,7 @@ pub fn create_share(measurement: &[u8], threshold: u32, epoch: &str) -> String {
   let WASMSharingMaterial { key, share, tag } = share_result.unwrap();
 
   let key_b64 = encode(key);
-  let share_b64 = encode(&share.to_bytes());
+  let share_b64 = encode(share.to_bytes());
   let tag_b64 = encode(tag);
 
   format!(


### PR DESCRIPTION
Address a couple of redundant code issues reported by clippy from rust 1.67 nightly.