### PR TITLE
ppoprf: Remove redundant base64 dependency

### DIFF
--- a/ppoprf/Cargo.toml
+++ b/ppoprf/Cargo.toml
@@ -15,13 +15,12 @@ curve25519-dalek =  { version = "3.2.0", features = [ "serde" ] }
 serde = "1.0.147"
 strobe-rs = "0.8.1"
 strobe-rng = { path = "../strobe-rng" }
-base64 = "0.13"
+base64 = "0.13.1"
 bincode = "1.3.3"
 derive_more = "0.99"
 zeroize = { version = "1.5.7", features = [ "derive" ] }
 
 [dev-dependencies]
-base64 = "0.13.1"
 criterion = "0.4.0"
 env_logger = "0.9.3"
 log = "0.4.17"


### PR DESCRIPTION
The main crate also depends on `base64` so there's no reason to list it separately as a dev-dependency.