### PR TITLE
Update finite field crate to 0.13

### DIFF
--- a/sharks/Cargo.toml
+++ b/sharks/Cargo.toml
@@ -26,7 +26,7 @@ zeroize_memory = ["zeroize"]
 rand = { version = "0.8.5", default-features = false }
 arbitrary = { version = "1.2.0", features = ["derive"], optional = true }
 zeroize = { version = "1.5.7", features = ["zeroize_derive"], optional = true }
-ff = { version = "0.12", features = ["derive"] }
+ff = { version = "0.13", features = ["derive"] }
 bitvec = { version = "1.0.1", default-features = false }
 byteorder = { version = "1", default-features = false }
 rand_core = { version = "0.6", default-features = false }

--- a/sharks/src/lib.rs
+++ b/sharks/src/lib.rs
@@ -159,7 +159,7 @@ mod tests {
   }
 
   fn fp_one() -> Fp {
-    Fp::one()
+    Fp::ONE
   }
 
   fn fp_two() -> Fp {
@@ -167,7 +167,7 @@ mod tests {
   }
 
   fn fp_one_repr() -> Vec<u8> {
-    (Fp::one()).to_repr().as_ref().to_vec()
+    fp_one().to_repr().as_ref().to_vec()
   }
 
   fn fp_two_repr() -> Vec<u8> {

--- a/sharks/src/share_ff.rs
+++ b/sharks/src/share_ff.rs
@@ -49,10 +49,10 @@ pub fn interpolate(shares: &[Share]) -> Result<Vec<u8>, &'static str> {
             .iter()
             .filter(|s_j| s_j.x != s_i.x)
             .map(|s_j| s_j.x * (s_j.x - s_i.x).invert().unwrap())
-            .fold(Fp::one(), |acc, x| acc * x); // take product of all fractions
+            .fold(Fp::ONE, |acc, x| acc * x); // take product of all fractions
           f * s_i.y[s]
         })
-        .fold(Fp::zero(), |acc, x| acc + x); // take sum of all field elements
+        .fold(Fp::ZERO, |acc, x| acc + x); // take sum of all field elements
       Vec::from(e) // turn into byte vector
     })
     .collect();
@@ -84,7 +84,7 @@ pub fn random_polynomial<R: rand::Rng>(s: Fp, k: u32, rng: &mut R) -> Vec<Fp> {
 pub fn get_evaluator(polys: Vec<Vec<Fp>>) -> Evaluator {
   Evaluator {
     polys,
-    x: Fp::zero(),
+    x: Fp::ZERO,
   }
 }
 
@@ -101,7 +101,7 @@ impl Evaluator {
       y: self
         .polys
         .iter()
-        .map(|p| p.iter().fold(Fp::zero(), |acc, c| acc * x + c))
+        .map(|p| p.iter().fold(Fp::ZERO, |acc, c| acc * x + c))
         .collect(),
     }
   }
@@ -118,7 +118,7 @@ impl Iterator for Evaluator {
   type Item = Share;
 
   fn next(&mut self) -> Option<Share> {
-    self.x += Fp::one();
+    self.x += Fp::ONE;
     Some(self.evaluate(self.x))
   }
 }
@@ -195,7 +195,7 @@ mod tests {
   use rand_chacha::rand_core::SeedableRng;
 
   fn fp_one() -> Fp {
-    Fp::one()
+    Fp::ONE
   }
 
   fn fp_two() -> Fp {


### PR DESCRIPTION
This release of the finite field crate replaces the `one()` and `zero()` methods with equivalent constants (they both return `Self`. So no functional change, but it's available in `const` contexts.

Includes #179.