### PR TITLE
ppoprf: Remove matches dependency

### DIFF
--- a/ppoprf/Cargo.toml
+++ b/ppoprf/Cargo.toml
@@ -27,7 +27,6 @@ log = "0.4.17"
 reqwest = { version = "0.11.14", features = [ "blocking", "json" ] }
 dotenvy = "0.15.6"
 insta = "1.26.0"
-matches = "0.1.10"
 tokio = { version = "1.25.0", features = ["macros", "rt-multi-thread", "time"] }
 warp = "0.3.3"
 

--- a/ppoprf/src/ggm.rs
+++ b/ppoprf/src/ggm.rs
@@ -236,7 +236,6 @@ fn bvcast_u8_to_usize(
 #[cfg(test)]
 mod tests {
   use super::*;
-  use matches::assert_matches;
 
   #[test]
   fn eval() -> Result<(), PPRFError> {
@@ -257,7 +256,7 @@ mod tests {
     ggm.eval(&x0, &mut out)?;
     ggm.puncture(&x0)?;
     // next step should error out
-    assert_matches!(ggm.eval(&x0, &mut out), Err(PPRFError::NoPrefixFound));
+    assert!(matches!(ggm.eval(&x0, &mut out), Err(PPRFError::NoPrefixFound)));
     Ok(())
   }
 
@@ -269,10 +268,10 @@ mod tests {
     ggm.puncture(&x0)?;
     ggm.puncture(&x1)?;
     // next step should error out
-    assert_matches!(
+    assert!(matches!(
       ggm.eval(&x0, &mut [0u8; 32]),
       Err(PPRFError::NoPrefixFound)
-    );
+    ));
     Ok(())
   }
 

--- a/ppoprf/src/ggm.rs
+++ b/ppoprf/src/ggm.rs
@@ -256,7 +256,10 @@ mod tests {
     ggm.eval(&x0, &mut out)?;
     ggm.puncture(&x0)?;
     // next step should error out
-    assert!(matches!(ggm.eval(&x0, &mut out), Err(PPRFError::NoPrefixFound)));
+    assert!(matches!(
+      ggm.eval(&x0, &mut out),
+      Err(PPRFError::NoPrefixFound)
+    ));
     Ok(())
   }
 


### PR DESCRIPTION
This crate is unmainted; the same functionality is available as `std::matches` since Rust 1.42. Prefer that version to reduce our dependency surface and avoid future audit warnings.