### PR TITLE
Batch ZK proofs for PPOPRF

### DIFF
--- a/ppoprf/src/ppoprf.rs
+++ b/ppoprf/src/ppoprf.rs
@@ -92,48 +92,38 @@ impl ProofDLEQ {
     I2OSP(len(a3), 2) || a3 ||
     "Challenge"*/
     let mut challenge_transcript = Vec::new();
-    challenge_transcript.extend_from_slice(
-      ProofDLEQ::i2osp(
-        &public_value.compress().as_bytes().len().to_be_bytes(), 
-        2,
-      )
-    );
+    challenge_transcript.extend_from_slice(ProofDLEQ::i2osp(
+      &public_value.compress().as_bytes().len().to_be_bytes(),
+      2,
+    ));
     challenge_transcript.extend_from_slice(public_value.compress().as_bytes()); //Bm
-    challenge_transcript.extend_from_slice(
-      ProofDLEQ::i2osp(
-        &m.compress().as_bytes().len().to_be_bytes(), 
-        2,
-      )
-    );
-    challenge_transcript.extend_from_slice(m.compress().as_bytes());  //a0 = m
-    challenge_transcript.extend_from_slice(
-      ProofDLEQ::i2osp(
-        &z.compress().as_bytes().len().to_be_bytes(), 
-        2,
-      )
-    );
-    challenge_transcript.extend_from_slice(z.compress().as_bytes());  //a1 = z
-    challenge_transcript.extend_from_slice(
-      ProofDLEQ::i2osp(
-        &t2.compress().as_bytes().len().to_be_bytes(), 
-        2,
-      )
-    );
+    challenge_transcript.extend_from_slice(ProofDLEQ::i2osp(
+      &m.compress().as_bytes().len().to_be_bytes(),
+      2,
+    ));
+    challenge_transcript.extend_from_slice(m.compress().as_bytes()); //a0 = m
+    challenge_transcript.extend_from_slice(ProofDLEQ::i2osp(
+      &z.compress().as_bytes().len().to_be_bytes(),
+      2,
+    ));
+    challenge_transcript.extend_from_slice(z.compress().as_bytes()); //a1 = z
+    challenge_transcript.extend_from_slice(ProofDLEQ::i2osp(
+      &t2.compress().as_bytes().len().to_be_bytes(),
+      2,
+    ));
     challenge_transcript.extend_from_slice(t2.compress().as_bytes()); //a2 = t2
-    challenge_transcript.extend_from_slice(
-      ProofDLEQ::i2osp(
-        &t3.compress().as_bytes().len().to_be_bytes(), 
-        2,
-      )
-    );
+    challenge_transcript.extend_from_slice(ProofDLEQ::i2osp(
+      &t3.compress().as_bytes().len().to_be_bytes(),
+      2,
+    ));
     challenge_transcript.extend_from_slice(t3.compress().as_bytes()); //a3 = t3
 
-  //c = G.HashToScalar(challengeTranscript)
-  let mut out = [0u8; 64];
-  strobe_hash(&challenge_transcript, "Challenge", &mut out);
-  let c = RistrettoScalar::from_bytes_mod_order_wide(&out);
-  //s = r - c * k
-  let s = r - c * key;
+    //c = G.HashToScalar(challengeTranscript)
+    let mut out = [0u8; 64];
+    strobe_hash(&challenge_transcript, "Challenge", &mut out);
+    let c = RistrettoScalar::from_bytes_mod_order_wide(&out);
+    //s = r - c * k
+    let s = r - c * key;
 
     //return [c, s]
     Self { c: c, s }
@@ -173,48 +163,38 @@ impl ProofDLEQ {
     let t3 = (self.s * m) + (self.c * z);
 
     /*challengeTranscript =
-      I2OSP(len(Bm), 2) || Bm ||
-      I2OSP(len(a0), 2) || a0 ||
-      I2OSP(len(a1), 2) || a1 ||
-      I2OSP(len(a2), 2) || a2 ||
-      I2OSP(len(a3), 2) || a3 ||
-      "Challenge"*/
-      let mut challenge_transcript = Vec::new();
-      challenge_transcript.extend_from_slice(
-        ProofDLEQ::i2osp(
-          &public_value.compress().as_bytes().len().to_be_bytes(), 
-          2,
-        )
-      );
-      challenge_transcript.extend_from_slice(public_value.compress().as_bytes()); //Bm
-      challenge_transcript.extend_from_slice(
-        ProofDLEQ::i2osp(
-          &m.compress().as_bytes().len().to_be_bytes(), 
-          2,
-        )
-      );
-      challenge_transcript.extend_from_slice(m.compress().as_bytes());  //a0 = m
-      challenge_transcript.extend_from_slice(
-        ProofDLEQ::i2osp(
-          &z.compress().as_bytes().len().to_be_bytes(), 
-          2,
-        )
-      );
-      challenge_transcript.extend_from_slice(z.compress().as_bytes());  //a1 = z
-      challenge_transcript.extend_from_slice(
-        ProofDLEQ::i2osp(
-          &t2.compress().as_bytes().len().to_be_bytes(), 
-          2,
-        )
-      );
-      challenge_transcript.extend_from_slice(t2.compress().as_bytes()); //a2 = t2
-      challenge_transcript.extend_from_slice(
-        ProofDLEQ::i2osp(
-          &t3.compress().as_bytes().len().to_be_bytes(), 
-          2,
-        )
-      );
-      challenge_transcript.extend_from_slice(t3.compress().as_bytes()); //a3 = t3
+    I2OSP(len(Bm), 2) || Bm ||
+    I2OSP(len(a0), 2) || a0 ||
+    I2OSP(len(a1), 2) || a1 ||
+    I2OSP(len(a2), 2) || a2 ||
+    I2OSP(len(a3), 2) || a3 ||
+    "Challenge"*/
+    let mut challenge_transcript = Vec::new();
+    challenge_transcript.extend_from_slice(ProofDLEQ::i2osp(
+      &public_value.compress().as_bytes().len().to_be_bytes(),
+      2,
+    ));
+    challenge_transcript.extend_from_slice(public_value.compress().as_bytes()); //Bm
+    challenge_transcript.extend_from_slice(ProofDLEQ::i2osp(
+      &m.compress().as_bytes().len().to_be_bytes(),
+      2,
+    ));
+    challenge_transcript.extend_from_slice(m.compress().as_bytes()); //a0 = m
+    challenge_transcript.extend_from_slice(ProofDLEQ::i2osp(
+      &z.compress().as_bytes().len().to_be_bytes(),
+      2,
+    ));
+    challenge_transcript.extend_from_slice(z.compress().as_bytes()); //a1 = z
+    challenge_transcript.extend_from_slice(ProofDLEQ::i2osp(
+      &t2.compress().as_bytes().len().to_be_bytes(),
+      2,
+    ));
+    challenge_transcript.extend_from_slice(t2.compress().as_bytes()); //a2 = t2
+    challenge_transcript.extend_from_slice(ProofDLEQ::i2osp(
+      &t3.compress().as_bytes().len().to_be_bytes(),
+      2,
+    ));
+    challenge_transcript.extend_from_slice(t3.compress().as_bytes()); //a3 = t3
 
     //c = G.HashToScalar(challengeTranscript)
     let mut out = [0u8; 64];
@@ -236,24 +216,20 @@ impl ProofDLEQ {
     }
 
     // We use the Partially-punctureable Oblivious Pseudo-Random Function
-    let context_string = format!("{}{}{}{}", 
-                                        "PPOPRFv1-", 
-                                        0x03, 
-                                        "-", 
-                                        "ristretto255-strobe");
+    let context_string =
+      format!("{}{}{}{}", "PPOPRFv1-", 0x03, "-", "ristretto255-strobe");
     //seedDST = "Seed-" || contextString
     let seed_dst = format!("{}{}", "Seed-", context_string);
 
     // seedTranscript = I2OSP(len(Bm), 2) || Bm || I2OSP(len(seedDST), 2) || seedDST
     let mut seed_transcript = Vec::new();
-    seed_transcript.extend_from_slice(
-      ProofDLEQ::i2osp(
-        &b.compress().as_bytes().len().to_be_bytes(), 
-        2
-      )
-    );
+    seed_transcript.extend_from_slice(ProofDLEQ::i2osp(
+      &b.compress().as_bytes().len().to_be_bytes(),
+      2,
+    ));
     seed_transcript.extend_from_slice(b.compress().as_bytes());
-    seed_transcript.extend_from_slice(ProofDLEQ::i2osp(&seed_dst.len().to_be_bytes(), 2));
+    seed_transcript
+      .extend_from_slice(ProofDLEQ::i2osp(&seed_dst.len().to_be_bytes(), 2));
     seed_transcript.extend_from_slice(seed_dst.as_bytes());
 
     let mut seed = [0u8; 64];
@@ -266,25 +242,23 @@ impl ProofDLEQ {
 
     // for i in range(m):
     for i in 0..c.len() {
-      //compositeTranscript = I2OSP(len(seed), 2) || seed || I2OSP(i, 2) || 
+      //compositeTranscript = I2OSP(len(seed), 2) || seed || I2OSP(i, 2) ||
       //                      I2OSP(len(C[i]), 2) || C[i] || I2OSP(len(D[i]), 2) || D[i] || "Composite"
       let mut composite_transcript = Vec::new();
-      composite_transcript.extend_from_slice(ProofDLEQ::i2osp(&seed.len().to_be_bytes(), 2));
+      composite_transcript
+        .extend_from_slice(ProofDLEQ::i2osp(&seed.len().to_be_bytes(), 2));
       composite_transcript.extend_from_slice(&seed);
-      composite_transcript.extend_from_slice(ProofDLEQ::i2osp(&i.to_be_bytes(), 2));
-      composite_transcript.extend_from_slice(
-        ProofDLEQ::i2osp(
-          &c[i].compress().as_bytes().len().to_be_bytes(), 
-          2
-        )
-      );
+      composite_transcript
+        .extend_from_slice(ProofDLEQ::i2osp(&i.to_be_bytes(), 2));
+      composite_transcript.extend_from_slice(ProofDLEQ::i2osp(
+        &c[i].compress().as_bytes().len().to_be_bytes(),
+        2,
+      ));
       composite_transcript.extend_from_slice(c[i].compress().as_bytes());
-      composite_transcript.extend_from_slice(
-        ProofDLEQ::i2osp(
-          &d[i].compress().as_bytes().len().to_be_bytes(), 
-          2
-        )
-      );
+      composite_transcript.extend_from_slice(ProofDLEQ::i2osp(
+        &d[i].compress().as_bytes().len().to_be_bytes(),
+        2,
+      ));
       composite_transcript.extend_from_slice(d[i].compress().as_bytes());
 
       //di = G.HashToScalar(compositeTranscript)
@@ -324,9 +298,9 @@ impl ProofDLEQ {
     RistrettoScalar::from_bytes_mod_order_wide(&out)
   }
 
-  // I2OSP(x, xLen): Converts a non-negative integer x into a byte 
+  // I2OSP(x, xLen): Converts a non-negative integer x into a byte
   // array of specified length xLen as described in [RFC8017]. Note
-  // that this function returns a byte array in big-endian byte 
+  // that this function returns a byte array in big-endian byte
   // order.
   pub fn i2osp(x: &[u8], x_len: usize) -> &[u8] {
     &x[0..x_len]
@@ -510,9 +484,9 @@ impl Server {
         &point,
       ));*/
       proof = Some(ProofDLEQ::new_batch(
-        &tagged_key, 
-        &public_value.into(), 
-        &[eval_point], 
+        &tagged_key,
+        &public_value.into(),
+        &[eval_point],
         &[point],
       ));
     }

--- a/ppoprf/src/ppoprf.rs
+++ b/ppoprf/src/ppoprf.rs
@@ -95,26 +95,26 @@ impl ProofDLEQ {
     let mut challenge_transcript = Vec::new();
     challenge_transcript.extend_from_slice(ProofDLEQ::i2osp(
       &public_value.compress().as_bytes().len().to_be_bytes(),
-      2,
+      2,  //len(Bm)
     ));
     challenge_transcript.extend_from_slice(public_value.compress().as_bytes()); //Bm
     challenge_transcript.extend_from_slice(ProofDLEQ::i2osp(
-      &m.compress().as_bytes().len().to_be_bytes(),
+      &m.compress().as_bytes().len().to_be_bytes(), //len(a0)
       2,
     ));
     challenge_transcript.extend_from_slice(m.compress().as_bytes()); //a0 = m
     challenge_transcript.extend_from_slice(ProofDLEQ::i2osp(
-      &z.compress().as_bytes().len().to_be_bytes(),
+      &z.compress().as_bytes().len().to_be_bytes(), //len(a1)
       2,
     ));
     challenge_transcript.extend_from_slice(z.compress().as_bytes()); //a1 = z
     challenge_transcript.extend_from_slice(ProofDLEQ::i2osp(
-      &t2.compress().as_bytes().len().to_be_bytes(),
+      &t2.compress().as_bytes().len().to_be_bytes(),  //len(a2)
       2,
     ));
     challenge_transcript.extend_from_slice(t2.compress().as_bytes()); //a2 = t2
     challenge_transcript.extend_from_slice(ProofDLEQ::i2osp(
-      &t3.compress().as_bytes().len().to_be_bytes(),
+      &t3.compress().as_bytes().len().to_be_bytes(),  //len(a3)
       2,
     ));
     challenge_transcript.extend_from_slice(t3.compress().as_bytes()); //a3 = t3
@@ -172,27 +172,27 @@ impl ProofDLEQ {
     "Challenge"*/
     let mut challenge_transcript = Vec::new();
     challenge_transcript.extend_from_slice(ProofDLEQ::i2osp(
-      &public_value.compress().as_bytes().len().to_be_bytes(),
+      &public_value.compress().as_bytes().len().to_be_bytes(),  //len(Bm)
       2,
     ));
     challenge_transcript.extend_from_slice(public_value.compress().as_bytes()); //Bm
     challenge_transcript.extend_from_slice(ProofDLEQ::i2osp(
-      &m.compress().as_bytes().len().to_be_bytes(),
+      &m.compress().as_bytes().len().to_be_bytes(), //len(a0)
       2,
     ));
     challenge_transcript.extend_from_slice(m.compress().as_bytes()); //a0 = m
     challenge_transcript.extend_from_slice(ProofDLEQ::i2osp(
-      &z.compress().as_bytes().len().to_be_bytes(),
+      &z.compress().as_bytes().len().to_be_bytes(),  //len(a1)
       2,
     ));
     challenge_transcript.extend_from_slice(z.compress().as_bytes()); //a1 = z
     challenge_transcript.extend_from_slice(ProofDLEQ::i2osp(
-      &t2.compress().as_bytes().len().to_be_bytes(),
+      &t2.compress().as_bytes().len().to_be_bytes(),   //len(a2)
       2,
     ));
     challenge_transcript.extend_from_slice(t2.compress().as_bytes()); //a2 = t2
     challenge_transcript.extend_from_slice(ProofDLEQ::i2osp(
-      &t3.compress().as_bytes().len().to_be_bytes(),
+      &t3.compress().as_bytes().len().to_be_bytes(),   //len(a3)
       2,
     ));
     challenge_transcript.extend_from_slice(t3.compress().as_bytes()); //a3 = t3
@@ -217,6 +217,7 @@ impl ProofDLEQ {
     }
 
     // We use the Partially-punctureable Oblivious Pseudo-Random Function
+    // We assign mode 0x03 for the PPOPRF
     let context_string =
       format!("{}{}{}{}", "PPOPRFv1-", 0x03, "-", "ristretto255-strobe");
     //seedDST = "Seed-" || contextString
@@ -225,13 +226,13 @@ impl ProofDLEQ {
     // seedTranscript = I2OSP(len(Bm), 2) || Bm || I2OSP(len(seedDST), 2) || seedDST
     let mut seed_transcript = Vec::new();
     seed_transcript.extend_from_slice(ProofDLEQ::i2osp(
-      &b.compress().as_bytes().len().to_be_bytes(),
+      &b.compress().as_bytes().len().to_be_bytes(),  //len(Bm)
       2,
     ));
-    seed_transcript.extend_from_slice(b.compress().as_bytes());
+    seed_transcript.extend_from_slice(b.compress().as_bytes()); //Bm
     seed_transcript
-      .extend_from_slice(ProofDLEQ::i2osp(&seed_dst.len().to_be_bytes(), 2));
-    seed_transcript.extend_from_slice(seed_dst.as_bytes());
+      .extend_from_slice(ProofDLEQ::i2osp(&seed_dst.len().to_be_bytes(), 2)); //len(seedDST)
+    seed_transcript.extend_from_slice(seed_dst.as_bytes()); //seedDST
 
     let mut seed = [0u8; 64];
     strobe_hash(&seed_transcript, "Seed", &mut seed);
@@ -247,20 +248,20 @@ impl ProofDLEQ {
       //                      I2OSP(len(C[i]), 2) || C[i] || I2OSP(len(D[i]), 2) || D[i] || "Composite"
       let mut composite_transcript = Vec::new();
       composite_transcript
-        .extend_from_slice(ProofDLEQ::i2osp(&seed.len().to_be_bytes(), 2));
-      composite_transcript.extend_from_slice(&seed);
+        .extend_from_slice(ProofDLEQ::i2osp(&seed.len().to_be_bytes(), 2)); //len(seed)
+      composite_transcript.extend_from_slice(&seed);  //seed
       composite_transcript
-        .extend_from_slice(ProofDLEQ::i2osp(&i.to_be_bytes(), 2));
+        .extend_from_slice(ProofDLEQ::i2osp(&i.to_be_bytes(), 2));  //len(i)
       composite_transcript.extend_from_slice(ProofDLEQ::i2osp(
-        &c[i].compress().as_bytes().len().to_be_bytes(),
+        &c[i].compress().as_bytes().len().to_be_bytes(),  //len(C[i])
         2,
       ));
-      composite_transcript.extend_from_slice(c[i].compress().as_bytes());
+      composite_transcript.extend_from_slice(c[i].compress().as_bytes()); //C[i]
       composite_transcript.extend_from_slice(ProofDLEQ::i2osp(
-        &d[i].compress().as_bytes().len().to_be_bytes(),
+        &d[i].compress().as_bytes().len().to_be_bytes(),  //len(D[i])
         2,
       ));
-      composite_transcript.extend_from_slice(d[i].compress().as_bytes());
+      composite_transcript.extend_from_slice(d[i].compress().as_bytes()); //D[i]
 
       //di = G.HashToScalar(compositeTranscript)
       let mut out = [0u8; 64];

--- a/ppoprf/src/ppoprf.rs
+++ b/ppoprf/src/ppoprf.rs
@@ -121,7 +121,7 @@ impl ProofDLEQ {
     challenge_transcript.extend_from_slice(t3.compress().as_bytes()); //a3 = t3
 
     //c = G.HashToScalar(challengeTranscript)
-    let mut out = [0u8; 64];
+    let mut out = [0u8; DIGEST_LEN];
     strobe_hash(&challenge_transcript, "Challenge", &mut out);
     let c = RistrettoScalar::from_bytes_mod_order_wide(&out);
     //s = r - c * k
@@ -200,7 +200,7 @@ impl ProofDLEQ {
     challenge_transcript.extend_from_slice(t3.compress().as_bytes()); //a3 = t3
 
     //c = G.HashToScalar(challengeTranscript)
-    let mut out = [0u8; 64];
+    let mut out = [0u8; DIGEST_LEN];
     strobe_hash(&challenge_transcript, "Challenge", &mut out);
     let expected_c = RistrettoScalar::from_bytes_mod_order_wide(&out);
 
@@ -221,7 +221,7 @@ impl ProofDLEQ {
     // We use the Partially-punctureable Oblivious Pseudo-Random Function
     // We assign mode 0x03 for the PPOPRF
     let context_string =
-      format!("{}{}{}{}", "PPOPRFv1-", 0x03, "-", "ristretto255-strobe");
+      format!("{}-{}-{}", "PPOPRFv1", 0x03, "ristretto255-strobe");
     //seedDST = "Seed-" || contextString
     let seed_dst = format!("{}{}", "Seed-", context_string);
 
@@ -236,7 +236,7 @@ impl ProofDLEQ {
       .extend_from_slice(ProofDLEQ::i2osp(&seed_dst.len().to_be_bytes(), 2)); //len(seedDST)
     seed_transcript.extend_from_slice(seed_dst.as_bytes()); //seedDST
 
-    let mut seed = [0u8; 64];
+    let mut seed = [0u8; DIGEST_LEN];
     strobe_hash(&seed_transcript, "Seed", &mut seed);
 
     //M = G.Identity()
@@ -266,7 +266,7 @@ impl ProofDLEQ {
       composite_transcript.extend_from_slice(d[i].compress().as_bytes()); //D[i]
 
       //di = G.HashToScalar(compositeTranscript)
-      let mut out = [0u8; 64];
+      let mut out = [0u8; DIGEST_LEN];
       strobe_hash(&composite_transcript, "Composite", &mut out);
       let di = RistrettoScalar::from_bytes_mod_order_wide(&out);
 

--- a/ppoprf/src/ppoprf.rs
+++ b/ppoprf/src/ppoprf.rs
@@ -94,30 +94,16 @@ impl ProofDLEQ {
     I2OSP(len(a3), 2) || a3 ||
     "Challenge"*/
     let mut challenge_transcript = Vec::new();
-    challenge_transcript.extend_from_slice(ProofDLEQ::i2osp(
-      &public_value.compress().as_bytes().len().to_be_bytes(),
-      2, //len(Bm)
-    ));
+    let compressed_point_len_slice = &ProofDLEQ::i2osp2(COMPRESSED_POINT_LEN);
+    challenge_transcript.extend_from_slice(compressed_point_len_slice); //len(Bm)
     challenge_transcript.extend_from_slice(public_value.compress().as_bytes()); //Bm
-    challenge_transcript.extend_from_slice(ProofDLEQ::i2osp(
-      &m.compress().as_bytes().len().to_be_bytes(), //len(a0)
-      2,
-    ));
+    challenge_transcript.extend_from_slice(compressed_point_len_slice); //len(a0)
     challenge_transcript.extend_from_slice(m.compress().as_bytes()); //a0 = m
-    challenge_transcript.extend_from_slice(ProofDLEQ::i2osp(
-      &z.compress().as_bytes().len().to_be_bytes(), //len(a1)
-      2,
-    ));
+    challenge_transcript.extend_from_slice(compressed_point_len_slice); //len(a1)
     challenge_transcript.extend_from_slice(z.compress().as_bytes()); //a1 = z
-    challenge_transcript.extend_from_slice(ProofDLEQ::i2osp(
-      &t2.compress().as_bytes().len().to_be_bytes(), //len(a2)
-      2,
-    ));
+    challenge_transcript.extend_from_slice(compressed_point_len_slice); //len(a2)
     challenge_transcript.extend_from_slice(t2.compress().as_bytes()); //a2 = t2
-    challenge_transcript.extend_from_slice(ProofDLEQ::i2osp(
-      &t3.compress().as_bytes().len().to_be_bytes(), //len(a3)
-      2,
-    ));
+    challenge_transcript.extend_from_slice(compressed_point_len_slice); //len(a3)
     challenge_transcript.extend_from_slice(t3.compress().as_bytes()); //a3 = t3
 
     //c = G.HashToScalar(challengeTranscript)
@@ -173,30 +159,16 @@ impl ProofDLEQ {
     I2OSP(len(a3), 2) || a3 ||
     "Challenge"*/
     let mut challenge_transcript = Vec::new();
-    challenge_transcript.extend_from_slice(ProofDLEQ::i2osp(
-      &public_value.compress().as_bytes().len().to_be_bytes(), //len(Bm)
-      2,
-    ));
+    let compressed_point_len_slice = &ProofDLEQ::i2osp2(COMPRESSED_POINT_LEN);
+    challenge_transcript.extend_from_slice(compressed_point_len_slice); //len(Bm)
     challenge_transcript.extend_from_slice(public_value.compress().as_bytes()); //Bm
-    challenge_transcript.extend_from_slice(ProofDLEQ::i2osp(
-      &m.compress().as_bytes().len().to_be_bytes(), //len(a0)
-      2,
-    ));
+    challenge_transcript.extend_from_slice(compressed_point_len_slice); //len(a0)
     challenge_transcript.extend_from_slice(m.compress().as_bytes()); //a0 = m
-    challenge_transcript.extend_from_slice(ProofDLEQ::i2osp(
-      &z.compress().as_bytes().len().to_be_bytes(), //len(a1)
-      2,
-    ));
+    challenge_transcript.extend_from_slice(compressed_point_len_slice); //len(a1)
     challenge_transcript.extend_from_slice(z.compress().as_bytes()); //a1 = z
-    challenge_transcript.extend_from_slice(ProofDLEQ::i2osp(
-      &t2.compress().as_bytes().len().to_be_bytes(), //len(a2)
-      2,
-    ));
+    challenge_transcript.extend_from_slice(compressed_point_len_slice); //len(a2)
     challenge_transcript.extend_from_slice(t2.compress().as_bytes()); //a2 = t2
-    challenge_transcript.extend_from_slice(ProofDLEQ::i2osp(
-      &t3.compress().as_bytes().len().to_be_bytes(), //len(a3)
-      2,
-    ));
+    challenge_transcript.extend_from_slice(compressed_point_len_slice); //len(a3)
     challenge_transcript.extend_from_slice(t3.compress().as_bytes()); //a3 = t3
 
     //c = G.HashToScalar(challengeTranscript)
@@ -227,13 +199,9 @@ impl ProofDLEQ {
 
     // seedTranscript = I2OSP(len(Bm), 2) || Bm || I2OSP(len(seedDST), 2) || seedDST
     let mut seed_transcript = Vec::new();
-    seed_transcript.extend_from_slice(ProofDLEQ::i2osp(
-      &b.compress().as_bytes().len().to_be_bytes(), //len(Bm)
-      2,
-    ));
+    seed_transcript.extend_from_slice(&ProofDLEQ::i2osp2(COMPRESSED_POINT_LEN)); //len(Bm)
     seed_transcript.extend_from_slice(b.compress().as_bytes()); //Bm
-    seed_transcript
-      .extend_from_slice(ProofDLEQ::i2osp(&seed_dst.len().to_be_bytes(), 2)); //len(seedDST)
+    seed_transcript.extend_from_slice(&ProofDLEQ::i2osp2(seed_dst.len())); //len(seedDST)
     seed_transcript.extend_from_slice(seed_dst.as_bytes()); //seedDST
 
     let mut seed = [0u8; DIGEST_LEN];
@@ -244,25 +212,18 @@ impl ProofDLEQ {
     //Z = G.Identity()
     let mut z = RistrettoPoint::identity();
 
+    let compressed_point_len_slice = &ProofDLEQ::i2osp2(COMPRESSED_POINT_LEN);
     // for i in range(m):
     for i in 0..c.len() {
       //compositeTranscript = I2OSP(len(seed), 2) || seed || I2OSP(i, 2) ||
       //                      I2OSP(len(C[i]), 2) || C[i] || I2OSP(len(D[i]), 2) || D[i] || "Composite"
       let mut composite_transcript = Vec::new();
-      composite_transcript
-        .extend_from_slice(ProofDLEQ::i2osp(&seed.len().to_be_bytes(), 2)); //len(seed)
+      composite_transcript.extend_from_slice(&ProofDLEQ::i2osp2(seed.len())); //len(seed)
       composite_transcript.extend_from_slice(&seed); //seed
-      composite_transcript
-        .extend_from_slice(ProofDLEQ::i2osp(&i.to_be_bytes(), 2)); //len(i)
-      composite_transcript.extend_from_slice(ProofDLEQ::i2osp(
-        &c[i].compress().as_bytes().len().to_be_bytes(), //len(C[i])
-        2,
-      ));
+      composite_transcript.extend_from_slice(&ProofDLEQ::i2osp2(i)); //len(i)
+      composite_transcript.extend_from_slice(compressed_point_len_slice); //len(C[i])
       composite_transcript.extend_from_slice(c[i].compress().as_bytes()); //C[i]
-      composite_transcript.extend_from_slice(ProofDLEQ::i2osp(
-        &d[i].compress().as_bytes().len().to_be_bytes(), //len(D[i])
-        2,
-      ));
+      composite_transcript.extend_from_slice(compressed_point_len_slice); //len(D[i])
       composite_transcript.extend_from_slice(d[i].compress().as_bytes()); //D[i]
 
       //di = G.HashToScalar(compositeTranscript)
@@ -302,15 +263,14 @@ impl ProofDLEQ {
     RistrettoScalar::from_bytes_mod_order_wide(&out)
   }
 
-  // I2OSP(x, xLen): Converts a non-negative integer x into a byte
-  // array of specified length xLen as described in [RFC8017]. Note
-  // that this function returns a byte array in big-endian byte
-  // order.
-  pub fn i2osp(x: &[u8], x_len: usize) -> &[u8] {
-    if (x_len as u32) > usize::BITS / 8 {
-      return x;
-    }
-    &x[x_len..]
+  // I2OSP2(x): Converts a non-negative integer x into a byte
+  // array of length 2 as described in [RFC8017]. Note that
+  // this function returns a byte array in big-endian byte order.
+  pub fn i2osp2(x: usize) -> [u8; 2] {
+    let mut z = [0u8; 2];
+    let y = &x.to_be_bytes();
+    z.clone_from_slice(&y[y.len() - 2..y.len()]);
+    z
   }
 
   pub fn serialize_to_bincode(&self) -> Result<Vec<u8>, PPRFError> {
@@ -762,13 +722,13 @@ mod tests {
   }
 
   #[test]
-  fn i2osp() {
-    assert_eq!(ProofDLEQ::i2osp(&42_u32.to_be_bytes(), 2), &[0, 42]);
-    assert_eq!(ProofDLEQ::i2osp(&255_u32.to_be_bytes(), 2), &[0, 255]);
-    assert_eq!(ProofDLEQ::i2osp(&256_u32.to_be_bytes(), 2), &[1, 0]);
-    assert_eq!(ProofDLEQ::i2osp(&511_u32.to_be_bytes(), 2), &[1, 255]);
-    assert_eq!(ProofDLEQ::i2osp(&65535_u32.to_be_bytes(), 2), &[255, 255]);
-    assert_eq!(ProofDLEQ::i2osp(&65536_u32.to_be_bytes(), 2), &[0, 0]); // [1,0,0]
+  fn i2osp2() {
+    assert_eq!(ProofDLEQ::i2osp2(42), [0, 42]);
+    assert_eq!(ProofDLEQ::i2osp2(255), [0, 255]);
+    assert_eq!(ProofDLEQ::i2osp2(256), [1, 0]);
+    assert_eq!(ProofDLEQ::i2osp2(511), [1, 255]);
+    assert_eq!(ProofDLEQ::i2osp2(65535), [255, 255]);
+    assert_eq!(ProofDLEQ::i2osp2(65536), [0, 0]); // [1,0,0]
   }
 
   #[test]

--- a/ppoprf/src/ppoprf.rs
+++ b/ppoprf/src/ppoprf.rs
@@ -95,7 +95,7 @@ impl ProofDLEQ {
     let mut challenge_transcript = Vec::new();
     challenge_transcript.extend_from_slice(ProofDLEQ::i2osp(
       &public_value.compress().as_bytes().len().to_be_bytes(),
-      2,  //len(Bm)
+      2, //len(Bm)
     ));
     challenge_transcript.extend_from_slice(public_value.compress().as_bytes()); //Bm
     challenge_transcript.extend_from_slice(ProofDLEQ::i2osp(
@@ -109,12 +109,12 @@ impl ProofDLEQ {
     ));
     challenge_transcript.extend_from_slice(z.compress().as_bytes()); //a1 = z
     challenge_transcript.extend_from_slice(ProofDLEQ::i2osp(
-      &t2.compress().as_bytes().len().to_be_bytes(),  //len(a2)
+      &t2.compress().as_bytes().len().to_be_bytes(), //len(a2)
       2,
     ));
     challenge_transcript.extend_from_slice(t2.compress().as_bytes()); //a2 = t2
     challenge_transcript.extend_from_slice(ProofDLEQ::i2osp(
-      &t3.compress().as_bytes().len().to_be_bytes(),  //len(a3)
+      &t3.compress().as_bytes().len().to_be_bytes(), //len(a3)
       2,
     ));
     challenge_transcript.extend_from_slice(t3.compress().as_bytes()); //a3 = t3
@@ -172,7 +172,7 @@ impl ProofDLEQ {
     "Challenge"*/
     let mut challenge_transcript = Vec::new();
     challenge_transcript.extend_from_slice(ProofDLEQ::i2osp(
-      &public_value.compress().as_bytes().len().to_be_bytes(),  //len(Bm)
+      &public_value.compress().as_bytes().len().to_be_bytes(), //len(Bm)
       2,
     ));
     challenge_transcript.extend_from_slice(public_value.compress().as_bytes()); //Bm
@@ -182,17 +182,17 @@ impl ProofDLEQ {
     ));
     challenge_transcript.extend_from_slice(m.compress().as_bytes()); //a0 = m
     challenge_transcript.extend_from_slice(ProofDLEQ::i2osp(
-      &z.compress().as_bytes().len().to_be_bytes(),  //len(a1)
+      &z.compress().as_bytes().len().to_be_bytes(), //len(a1)
       2,
     ));
     challenge_transcript.extend_from_slice(z.compress().as_bytes()); //a1 = z
     challenge_transcript.extend_from_slice(ProofDLEQ::i2osp(
-      &t2.compress().as_bytes().len().to_be_bytes(),   //len(a2)
+      &t2.compress().as_bytes().len().to_be_bytes(), //len(a2)
       2,
     ));
     challenge_transcript.extend_from_slice(t2.compress().as_bytes()); //a2 = t2
     challenge_transcript.extend_from_slice(ProofDLEQ::i2osp(
-      &t3.compress().as_bytes().len().to_be_bytes(),   //len(a3)
+      &t3.compress().as_bytes().len().to_be_bytes(), //len(a3)
       2,
     ));
     challenge_transcript.extend_from_slice(t3.compress().as_bytes()); //a3 = t3
@@ -226,7 +226,7 @@ impl ProofDLEQ {
     // seedTranscript = I2OSP(len(Bm), 2) || Bm || I2OSP(len(seedDST), 2) || seedDST
     let mut seed_transcript = Vec::new();
     seed_transcript.extend_from_slice(ProofDLEQ::i2osp(
-      &b.compress().as_bytes().len().to_be_bytes(),  //len(Bm)
+      &b.compress().as_bytes().len().to_be_bytes(), //len(Bm)
       2,
     ));
     seed_transcript.extend_from_slice(b.compress().as_bytes()); //Bm
@@ -249,16 +249,16 @@ impl ProofDLEQ {
       let mut composite_transcript = Vec::new();
       composite_transcript
         .extend_from_slice(ProofDLEQ::i2osp(&seed.len().to_be_bytes(), 2)); //len(seed)
-      composite_transcript.extend_from_slice(&seed);  //seed
+      composite_transcript.extend_from_slice(&seed); //seed
       composite_transcript
-        .extend_from_slice(ProofDLEQ::i2osp(&i.to_be_bytes(), 2));  //len(i)
+        .extend_from_slice(ProofDLEQ::i2osp(&i.to_be_bytes(), 2)); //len(i)
       composite_transcript.extend_from_slice(ProofDLEQ::i2osp(
-        &c[i].compress().as_bytes().len().to_be_bytes(),  //len(C[i])
+        &c[i].compress().as_bytes().len().to_be_bytes(), //len(C[i])
         2,
       ));
       composite_transcript.extend_from_slice(c[i].compress().as_bytes()); //C[i]
       composite_transcript.extend_from_slice(ProofDLEQ::i2osp(
-        &d[i].compress().as_bytes().len().to_be_bytes(),  //len(D[i])
+        &d[i].compress().as_bytes().len().to_be_bytes(), //len(D[i])
         2,
       ));
       composite_transcript.extend_from_slice(d[i].compress().as_bytes()); //D[i]
@@ -482,17 +482,11 @@ impl Server {
     let mut proof = None;
     if verifiable {
       let public_value = self.public_key.get_combined_pk_value(md)?;
-      /*proof = Some(ProofDLEQ::new(
+      proof = Some(ProofDLEQ::new(
         &tagged_key,
         &public_value.into(),
         &eval_point,
         &point,
-      ));*/
-      proof = Some(ProofDLEQ::new_batch(
-        &tagged_key,
-        &public_value.into(),
-        &[eval_point],
-        &[point],
       ));
     }
     Ok(Evaluation {
@@ -531,15 +525,10 @@ impl Client {
   ) -> bool {
     let Evaluation { output, proof } = eval;
     if let Ok(public_value) = public_key.get_combined_pk_value(md) {
-      /*return proof.as_ref().unwrap().verify(
+      return proof.as_ref().unwrap().verify(
         &public_value.into(),
         &output.decompress().unwrap(),
         &input.decompress().unwrap(),
-      );*/
-      return proof.as_ref().unwrap().verify_batch(
-        &public_value.into(),
-        &[output.decompress().unwrap()],
-        &[input.decompress().unwrap()],
       );
     }
     false

--- a/ppoprf/src/ppoprf.rs
+++ b/ppoprf/src/ppoprf.rs
@@ -221,6 +221,10 @@ impl ProofDLEQ {
     c: &[RistrettoPoint],
     d: &[RistrettoPoint],
   ) -> (RistrettoPoint, RistrettoPoint){
+    if c.len() != d.len() {
+      panic!("C and D have a different number of elements!");
+    }
+
     //Bm = G.SerializeElement(B)
     let bm_string = ProofDLEQ::serialize_element(*b);
 
@@ -255,7 +259,7 @@ impl ProofDLEQ {
     };
 
     // for i in range(m):
-    for i in 0..5 {
+    for i in 0..c.len() {
       //Ci = G.SerializeElement(C[i])
       let ci_string = ProofDLEQ::serialize_element(c[i]);
       //Di = G.SerializeElement(D[i])

--- a/ppoprf/src/ppoprf.rs
+++ b/ppoprf/src/ppoprf.rs
@@ -781,24 +781,26 @@ mod tests {
     let eval_point1 = exponent * point1;
     let eval_point2 = exponent * point2;
     let eval_point3 = exponent * point3;
-    
+
     let public_value = server.public_key.get_combined_pk_value(0).unwrap();
 
     // Create one proof for multiple inputs
     let proof = Some(ProofDLEQ::new_batch(
-      &tagged_key, 
-      &public_value.into(), 
-      &[eval_point1, eval_point2, eval_point3], 
-      &[point1, point2, point3])
-    );
+      &tagged_key,
+      &public_value.into(),
+      &[eval_point1, eval_point2, eval_point3],
+      &[point1, point2, point3],
+    ));
 
     // verify multiple inputs in one proof
-    let public_value_verify = server.public_key.get_combined_pk_value(0).unwrap();
-    
+    let public_value_verify =
+      server.public_key.get_combined_pk_value(0).unwrap();
+
     let result = proof.as_ref().unwrap().verify_batch(
-      &public_value_verify.into(), 
+      &public_value_verify.into(),
       &[eval_point1, eval_point2, eval_point3],
-      &[point1, point2, point3]); 
+      &[point1, point2, point3],
+    );
 
     assert_eq!(result, true);
   }

--- a/ppoprf/src/ppoprf.rs
+++ b/ppoprf/src/ppoprf.rs
@@ -77,7 +77,7 @@ impl ProofDLEQ {
     q: &[RistrettoPoint],           //D
   ) -> Self {
     //(M, Z) = ComputeCompositesFast(k, B, C, D)
-    let (M, Z) = ProofDLEQ::computeComposites(
+    let (m, z) = ProofDLEQ::compute_composites(
       Some(*key),
       public_value,
       p, 
@@ -89,7 +89,7 @@ impl ProofDLEQ {
     //t2 = r * A
     let t2 = r * RISTRETTO_BASEPOINT_POINT;
     //t3 = r * M
-    let t3 = r * M;
+    let t3 = r * m;
 
     //Bm = G.SerializeElement(B)
     let bm_string = ProofDLEQ::serialize_element(*public_value);
@@ -98,8 +98,8 @@ impl ProofDLEQ {
     a1 = G.SerializeElement(Z)
     a2 = G.SerializeElement(t2)
     a3 = G.SerializeElement(t3) */
-    let a0_string = ProofDLEQ::serialize_element(M);
-    let a1_string = ProofDLEQ::serialize_element(Z);
+    let a0_string = ProofDLEQ::serialize_element(m);
+    let a1_string = ProofDLEQ::serialize_element(z);
     let a2_string = ProofDLEQ::serialize_element(t2);
     let a3_string = ProofDLEQ::serialize_element(t3);
 
@@ -152,14 +152,14 @@ impl ProofDLEQ {
     c_prime == self.c
   }
 
-  fn verifyBatch(
+  fn verify_batch(
     &self, 
     public_value: &RistrettoPoint,
     p: &[RistrettoPoint],           //P
     q: &[RistrettoPoint],           //Q
   ) -> bool {
     //(M, Z) = ComputeComposites(B, C, D)
-    let (M, Z) = ProofDLEQ::computeComposites(
+    let (m, z) = ProofDLEQ::compute_composites(
       None,
       public_value, 
       p, 
@@ -169,7 +169,7 @@ impl ProofDLEQ {
     //t2 = ((s * A) + (c * B))
     let t2 = (self.s * RISTRETTO_BASEPOINT_POINT) + (self.c * public_value);
     //t3 = ((s * M) + (c * Z))
-    let t3 = (self.s * M) + (self.c * Z);
+    let t3 = (self.s * m) + (self.c * z);
 
     //Bm = G.SerializeElement(B)
     let bm_string = ProofDLEQ::serialize_element(*public_value);
@@ -178,8 +178,8 @@ impl ProofDLEQ {
     a1 = G.SerializeElement(Z)
     a2 = G.SerializeElement(t2)
     a3 = G.SerializeElement(t3) */
-    let a0_string = ProofDLEQ::serialize_element(M);
-    let a1_string = ProofDLEQ::serialize_element(Z);
+    let a0_string = ProofDLEQ::serialize_element(m);
+    let a1_string = ProofDLEQ::serialize_element(z);
     let a2_string = ProofDLEQ::serialize_element(t2);
     let a3_string = ProofDLEQ::serialize_element(t3);
 
@@ -211,7 +211,7 @@ impl ProofDLEQ {
     return expected_c == self.c
   }
 
-  fn computeComposites(
+  fn compute_composites(
     key: Option<RistrettoScalar>,
     b: &RistrettoPoint,
     c: &[RistrettoPoint],
@@ -244,9 +244,9 @@ impl ProofDLEQ {
     strobe_hash(&seed_transcript.as_bytes(), "Seed", &mut seed);
 
     //M = G.Identity()
-    let mut M = RISTRETTO_BASEPOINT_POINT;
+    let mut m = RISTRETTO_BASEPOINT_POINT;
     //Z = G.Identity()
-    let mut Z = RISTRETTO_BASEPOINT_POINT;
+    let mut z = RISTRETTO_BASEPOINT_POINT;
 
     let seed_string = match str::from_utf8(&seed) {
       Ok(v) => v,
@@ -277,22 +277,22 @@ impl ProofDLEQ {
       let di = RistrettoScalar::from_bytes_mod_order_wide(&out);
 
       //M = di * C[i] + M
-      M = di * c[i] + M;
+      m = di * c[i] + m;
 
       // If we know the key (server), we don't need to calculate Z here
       if key.is_none() {
         //Z = di * D[i] + Z
-        Z = di * d[i] + Z;
+        z = di * d[i] + z;
       }
     }
 
     // If we know the key (server), we can calulate Z from key and M
     if let Some(k) = key { 
-      Z = k * M;
+      z = k * m;
     }
   
     // return (M, Z)
-    (M, Z)
+    (m, z)
   }
 
   fn hash(elements: &[&RistrettoPoint]) -> RistrettoScalar {

--- a/ppoprf/src/ppoprf.rs
+++ b/ppoprf/src/ppoprf.rs
@@ -71,18 +71,13 @@ impl ProofDLEQ {
   }
 
   fn new_batch(
-    key: &RistrettoScalar,          //k
-    public_value: &RistrettoPoint,  //Y -> B
-    p: &[RistrettoPoint],           //C
-    q: &[RistrettoPoint],           //D
+    key: &RistrettoScalar,         //k
+    public_value: &RistrettoPoint, //Y -> B
+    p: &[RistrettoPoint],          //C
+    q: &[RistrettoPoint],          //D
   ) -> Self {
     //(M, Z) = ComputeCompositesFast(k, B, C, D)
-    let (m, z) = ProofDLEQ::compute_composites(
-      Some(*key),
-      public_value,
-      p, 
-      q,
-    );
+    let (m, z) = ProofDLEQ::compute_composites(Some(*key), public_value, p, q);
     //r = G.RandomScalar()
     let mut csprng = OsRng;
     let r = RistrettoScalar::random(&mut csprng);
@@ -110,27 +105,29 @@ impl ProofDLEQ {
     I2OSP(len(a2), 2) || a2 ||
     I2OSP(len(a3), 2) || a3 ||
     "Challenge"*/
-    let challenge_transcript = format!("{}{}{}{}{}{}{}{}{}{}",
-                                             bm_string.len(), 
-                                             bm_string, 
-                                             a0_string.len(),
-                                             a0_string,
-                                             a1_string.len(),
-                                             a1_string,
-                                             a2_string.len(),
-                                             a2_string,
-                                             a3_string.len(),
-                                             a3_string); 
+    let challenge_transcript = format!(
+      "{}{}{}{}{}{}{}{}{}{}",
+      bm_string.len(),
+      bm_string,
+      a0_string.len(),
+      a0_string,
+      a1_string.len(),
+      a1_string,
+      a2_string.len(),
+      a2_string,
+      a3_string.len(),
+      a3_string
+    );
 
-  //c = G.HashToScalar(challengeTranscript)
-  let mut out = [0u8; 64];
-  strobe_hash(&challenge_transcript.as_bytes(), "Challenge", &mut out);
-  let c = RistrettoScalar::from_bytes_mod_order_wide(&out);
-  //s = r - c * k
-  let s = r - c * key;
+    //c = G.HashToScalar(challengeTranscript)
+    let mut out = [0u8; 64];
+    strobe_hash(&challenge_transcript.as_bytes(), "Challenge", &mut out);
+    let c = RistrettoScalar::from_bytes_mod_order_wide(&out);
+    //s = r - c * k
+    let s = r - c * key;
 
-  //return [c, s]
-  Self { c: c, s }
+    //return [c, s]
+    Self { c: c, s }
   }
 
   fn verify(
@@ -153,18 +150,13 @@ impl ProofDLEQ {
   }
 
   fn verify_batch(
-    &self, 
+    &self,
     public_value: &RistrettoPoint,
-    p: &[RistrettoPoint],           //P
-    q: &[RistrettoPoint],           //Q
+    p: &[RistrettoPoint], //P
+    q: &[RistrettoPoint], //Q
   ) -> bool {
     //(M, Z) = ComputeComposites(B, C, D)
-    let (m, z) = ProofDLEQ::compute_composites(
-      None,
-      public_value, 
-      p, 
-      q,
-    );
+    let (m, z) = ProofDLEQ::compute_composites(None, public_value, p, q);
 
     //t2 = ((s * A) + (c * B))
     let t2 = (self.s * RISTRETTO_BASEPOINT_POINT) + (self.c * public_value);
@@ -184,31 +176,33 @@ impl ProofDLEQ {
     let a3_string = ProofDLEQ::serialize_element(t3);
 
     /*challengeTranscript =
-      I2OSP(len(Bm), 2) || Bm ||
-      I2OSP(len(a0), 2) || a0 ||
-      I2OSP(len(a1), 2) || a1 ||
-      I2OSP(len(a2), 2) || a2 ||
-      I2OSP(len(a3), 2) || a3 ||
-      "Challenge"*/
-      let challenge_transcript = format!("{}{}{}{}{}{}{}{}{}{}",
-                                               bm_string.len(), 
-                                               bm_string, 
-                                               a0_string.len(),
-                                               a0_string,
-                                               a1_string.len(),
-                                               a1_string,
-                                               a2_string.len(),
-                                               a2_string,
-                                               a3_string.len(),
-                                               a3_string); 
+    I2OSP(len(Bm), 2) || Bm ||
+    I2OSP(len(a0), 2) || a0 ||
+    I2OSP(len(a1), 2) || a1 ||
+    I2OSP(len(a2), 2) || a2 ||
+    I2OSP(len(a3), 2) || a3 ||
+    "Challenge"*/
+    let challenge_transcript = format!(
+      "{}{}{}{}{}{}{}{}{}{}",
+      bm_string.len(),
+      bm_string,
+      a0_string.len(),
+      a0_string,
+      a1_string.len(),
+      a1_string,
+      a2_string.len(),
+      a2_string,
+      a3_string.len(),
+      a3_string
+    );
 
     //c = G.HashToScalar(challengeTranscript)
     let mut out = [0u8; 64];
     strobe_hash(&challenge_transcript.as_bytes(), "Challenge", &mut out);
     let expected_c = RistrettoScalar::from_bytes_mod_order_wide(&out);
-  
+
     //verified = (expectedC == c)
-    return expected_c == self.c
+    return expected_c == self.c;
   }
 
   fn compute_composites(
@@ -216,7 +210,7 @@ impl ProofDLEQ {
     b: &RistrettoPoint,
     c: &[RistrettoPoint],
     d: &[RistrettoPoint],
-  ) -> (RistrettoPoint, RistrettoPoint){
+  ) -> (RistrettoPoint, RistrettoPoint) {
     if c.len() != d.len() {
       panic!("C and D have a different number of elements!");
     }
@@ -225,20 +219,24 @@ impl ProofDLEQ {
     let bm_string = ProofDLEQ::serialize_element(*b);
 
     // We use the Partially-punctureable Oblivious Pseudo-Random Function
-    let context_string = format!("{}{}{}{}", 
-                                        "PPOPRFv1-", 
-                                        0x03.to_string(), 
-                                        "-", 
-                                        "ristretto255-strobe");
+    let context_string = format!(
+      "{}{}{}{}",
+      "PPOPRFv1-",
+      0x03.to_string(),
+      "-",
+      "ristretto255-strobe"
+    );
     //seedDST = "Seed-" || contextString
     let seed_dst = format!("{}{}", "Seed-", context_string);
 
     // seedTranscript = I2OSP(len(Bm), 2) || Bm || I2OSP(len(seedDST), 2) || seedDST
-    let seed_transcript = format!("{}{}{}{}", 
-                                         bm_string.len(), 
-                                         bm_string, 
-                                         seed_dst.len(), 
-                                         seed_dst);
+    let seed_transcript = format!(
+      "{}{}{}{}",
+      bm_string.len(),
+      bm_string,
+      seed_dst.len(),
+      seed_dst
+    );
 
     let mut seed = [0u8; 64];
     strobe_hash(&seed_transcript.as_bytes(), "Seed", &mut seed);
@@ -260,16 +258,18 @@ impl ProofDLEQ {
       //Di = G.SerializeElement(D[i])
       let di_string = ProofDLEQ::serialize_element(d[i]);
 
-      //compositeTranscript = I2OSP(len(seed), 2) || seed || I2OSP(i, 2) || 
+      //compositeTranscript = I2OSP(len(seed), 2) || seed || I2OSP(i, 2) ||
       //                      I2OSP(len(Ci), 2) || Ci || I2OSP(len(Di), 2) || Di || "Composite"
-      let composite_transcript = format!("{}{}{}{}{}{}{}",
-                                                seed.len().to_string(), 
-                                                seed_string, 
-                                                i.to_string(),
-                                                ci_string.len(),
-                                                ci_string,
-                                                di_string.len(),
-                                                di_string); 
+      let composite_transcript = format!(
+        "{}{}{}{}{}{}{}",
+        seed.len().to_string(),
+        seed_string,
+        i.to_string(),
+        ci_string.len(),
+        ci_string,
+        di_string.len(),
+        di_string
+      );
 
       //di = G.HashToScalar(compositeTranscript)
       let mut out = [0u8; 64];
@@ -287,10 +287,10 @@ impl ProofDLEQ {
     }
 
     // If we know the key (server), we can calulate Z from key and M
-    if let Some(k) = key { 
+    if let Some(k) = key {
       z = k * m;
     }
-  
+
     // return (M, Z)
     (m, z)
   }

--- a/ppoprf/src/ppoprf.rs
+++ b/ppoprf/src/ppoprf.rs
@@ -266,7 +266,7 @@ impl ProofDLEQ {
     let mut uniform_bytes = [0u8; DIGEST_LEN];
     // strobe_hash() -> expand_msg_xmd
     // strobe_hash uses Keccak internally
-    strobe_hash(&input, label, &mut uniform_bytes);
+    strobe_hash(input, label, &mut uniform_bytes);
 
     // convert hash output to scalar
     ProofDLEQ::os2ip(&uniform_bytes)

--- a/ppoprf/src/ppoprf.rs
+++ b/ppoprf/src/ppoprf.rs
@@ -266,10 +266,11 @@ impl ProofDLEQ {
   // I2OSP2(x): Converts a non-negative integer x into a byte
   // array of length 2 as described in [RFC8017]. Note that
   // this function returns a byte array in big-endian byte order.
-  pub fn i2osp2(x: usize) -> [u8; 2] {
+  fn i2osp2(x: usize) -> [u8; 2] {
+    let x_u16: u16 = x.try_into().expect("integer too large");
+    let y = x_u16.to_be_bytes();
     let mut z = [0u8; 2];
-    let y = &x.to_be_bytes();
-    z.clone_from_slice(&y[y.len() - 2..y.len()]);
+    z.clone_from_slice(&y[y.len() - 2..]);
     z
   }
 
@@ -728,7 +729,12 @@ mod tests {
     assert_eq!(ProofDLEQ::i2osp2(256), [1, 0]);
     assert_eq!(ProofDLEQ::i2osp2(511), [1, 255]);
     assert_eq!(ProofDLEQ::i2osp2(65535), [255, 255]);
-    assert_eq!(ProofDLEQ::i2osp2(65536), [0, 0]); // [1,0,0]
+  }
+
+  #[test]
+  #[should_panic]
+  fn i2osp2_overflow() {
+    ProofDLEQ::i2osp2(65536); // [1,0,0]
   }
 
   #[test]

--- a/ppoprf/src/ppoprf.rs
+++ b/ppoprf/src/ppoprf.rs
@@ -224,12 +224,12 @@ impl ProofDLEQ {
     //Bm = G.SerializeElement(B)
     let bm_string = ProofDLEQ::serialize_element(*b);
 
-    // TODO check if the context string is correct
+    // We use the Partially-punctureable Oblivious Pseudo-Random Function
     let context_string = format!("{}{}{}{}", 
-                                        "OPRFV1-", 
-                                        0x01.to_string(), 
+                                        "PPOPRFv1-", 
+                                        0x03.to_string(), 
                                         "-", 
-                                        "ristretto255-SHA512");
+                                        "ristretto255-strobe");
     //seedDST = "Seed-" || contextString
     let seed_dst = format!("{}{}", "Seed-", context_string);
 

--- a/ppoprf/src/ppoprf.rs
+++ b/ppoprf/src/ppoprf.rs
@@ -781,6 +781,6 @@ mod tests {
       &[point1, point2, point3],
     );
 
-    assert_eq!(result, true);
+    assert!(result)
   }
 }

--- a/ppoprf/src/ppoprf.rs
+++ b/ppoprf/src/ppoprf.rs
@@ -195,7 +195,7 @@ impl ProofDLEQ {
     let context_string =
       format!("{}-{}-{}", "PPOPRFv1", 0x03, "ristretto255-strobe");
     //seedDST = "Seed-" || contextString
-    let seed_dst = format!("{}{}", "Seed-", context_string);
+    let seed_dst = format!("{}-{}", "Seed", context_string);
 
     // seedTranscript = I2OSP(len(Bm), 2) || Bm || I2OSP(len(seedDST), 2) || seedDST
     let mut seed_transcript = Vec::new();

--- a/ppoprf/src/ppoprf.rs
+++ b/ppoprf/src/ppoprf.rs
@@ -268,10 +268,7 @@ impl ProofDLEQ {
   // this function returns a byte array in big-endian byte order.
   fn i2osp2(x: usize) -> [u8; 2] {
     let x_u16: u16 = x.try_into().expect("integer too large");
-    let y = x_u16.to_be_bytes();
-    let mut z = [0u8; 2];
-    z.clone_from_slice(&y[y.len() - 2..]);
-    z
+    x_u16.to_be_bytes()
   }
 
   pub fn serialize_to_bincode(&self) -> Result<Vec<u8>, PPRFError> {

--- a/ppoprf/src/ppoprf.rs
+++ b/ppoprf/src/ppoprf.rs
@@ -445,12 +445,6 @@ impl Server {
     let mut proof = None;
     if verifiable {
       let public_value = self.public_key.get_combined_pk_value(md)?;
-      /*proof = Some(ProofDLEQ::new(
-        &tagged_key,
-        &public_value.into(),
-        &eval_point,
-        &point,
-      ));*/
       proof = Some(ProofDLEQ::new_batch(
         &tagged_key,
         &public_value.into(),
@@ -494,11 +488,6 @@ impl Client {
   ) -> bool {
     let Evaluation { output, proof } = eval;
     if let Ok(public_value) = public_key.get_combined_pk_value(md) {
-      /*return proof.as_ref().unwrap().verify(
-        &public_value.into(),
-        &output.decompress().unwrap(),
-        &input.decompress().unwrap(),
-      );*/
       return proof.as_ref().unwrap().verify_batch(
         &public_value.into(),
         &[output.decompress().unwrap()],

--- a/ppoprf/src/ppoprf.rs
+++ b/ppoprf/src/ppoprf.rs
@@ -14,6 +14,7 @@
 extern crate rand;
 
 extern crate rand_core;
+use curve25519_dalek::traits::Identity;
 use rand_core::RngCore;
 use rand_core_ristretto::OsRng;
 
@@ -236,9 +237,9 @@ impl ProofDLEQ {
     strobe_hash(&seed_transcript, "Seed", &mut seed);
 
     //M = G.Identity()
-    let mut m = RISTRETTO_BASEPOINT_POINT;
+    let mut m = RistrettoPoint::identity();
     //Z = G.Identity()
-    let mut z = RISTRETTO_BASEPOINT_POINT;
+    let mut z = RistrettoPoint::identity();
 
     // for i in range(m):
     for i in 0..c.len() {

--- a/ppoprf/src/ppoprf.rs
+++ b/ppoprf/src/ppoprf.rs
@@ -110,7 +110,7 @@ impl ProofDLEQ {
     I2OSP(len(a2), 2) || a2 ||
     I2OSP(len(a3), 2) || a3 ||
     "Challenge"*/
-    let challenge_transcript = format!("{}{}{}{}{}{}{}{}{}{}{}",
+    let challenge_transcript = format!("{}{}{}{}{}{}{}{}{}{}",
                                              bm_string.len(), 
                                              bm_string, 
                                              a0_string.len(),
@@ -120,12 +120,10 @@ impl ProofDLEQ {
                                              a2_string.len(),
                                              a2_string,
                                              a3_string.len(),
-                                             a3_string,
-                                             "Challenge"); 
+                                             a3_string); 
 
   //c = G.HashToScalar(challengeTranscript)
   let mut out = [0u8; 64];
-  // TODO label?
   strobe_hash(&challenge_transcript.as_bytes(), "Challenge", &mut out);
   let c = RistrettoScalar::from_bytes_mod_order_wide(&out);
   //s = r - c * k
@@ -192,7 +190,7 @@ impl ProofDLEQ {
       I2OSP(len(a2), 2) || a2 ||
       I2OSP(len(a3), 2) || a3 ||
       "Challenge"*/
-      let challenge_transcript = format!("{}{}{}{}{}{}{}{}{}{}{}",
+      let challenge_transcript = format!("{}{}{}{}{}{}{}{}{}{}",
                                                bm_string.len(), 
                                                bm_string, 
                                                a0_string.len(),
@@ -202,12 +200,10 @@ impl ProofDLEQ {
                                                a2_string.len(),
                                                a2_string,
                                                a3_string.len(),
-                                               a3_string,
-                                               "Challenge"); 
+                                               a3_string); 
 
     //c = G.HashToScalar(challengeTranscript)
     let mut out = [0u8; 64];
-    // TODO label?
     strobe_hash(&challenge_transcript.as_bytes(), "Challenge", &mut out);
     let expected_c = RistrettoScalar::from_bytes_mod_order_wide(&out);
   
@@ -244,7 +240,6 @@ impl ProofDLEQ {
                                          seed_dst.len(), 
                                          seed_dst);
 
-    // TODO what is the correct label? what's the digest length?
     let mut seed = [0u8; 64];
     strobe_hash(&seed_transcript.as_bytes(), "Seed", &mut seed);
 
@@ -267,19 +262,17 @@ impl ProofDLEQ {
 
       //compositeTranscript = I2OSP(len(seed), 2) || seed || I2OSP(i, 2) || 
       //                      I2OSP(len(Ci), 2) || Ci || I2OSP(len(Di), 2) || Di || "Composite"
-      let composite_transcript = format!("{}{}{}{}{}{}{}{}",
+      let composite_transcript = format!("{}{}{}{}{}{}{}",
                                                 seed.len().to_string(), 
                                                 seed_string, 
                                                 i.to_string(),
                                                 ci_string.len(),
                                                 ci_string,
                                                 di_string.len(),
-                                                di_string,
-                                                "Composite"); 
+                                                di_string); 
 
       //di = G.HashToScalar(compositeTranscript)
       let mut out = [0u8; 64];
-      // TODO label?
       strobe_hash(&composite_transcript.as_bytes(), "Composite", &mut out);
       let di = RistrettoScalar::from_bytes_mod_order_wide(&out);
 
@@ -302,7 +295,6 @@ impl ProofDLEQ {
     (M, Z)
   }
 
-  // H3
   fn hash(elements: &[&RistrettoPoint]) -> RistrettoScalar {
     if elements.len() != 6 {
       panic!("Incorrect number of points sent: {}", elements.len());

--- a/ppoprf/src/ppoprf.rs
+++ b/ppoprf/src/ppoprf.rs
@@ -46,6 +46,7 @@ pub struct ProofDLEQ {
   s: RistrettoScalar,
 }
 impl ProofDLEQ {
+  #[allow(dead_code)]
   fn new(
     key: &RistrettoScalar,
     public_value: &RistrettoPoint,
@@ -127,9 +128,10 @@ impl ProofDLEQ {
     let s = r - c * key;
 
     //return [c, s]
-    Self { c: c, s }
+    Self { c, s }
   }
 
+  #[allow(dead_code)]
   fn verify(
     &self,
     public_value: &RistrettoPoint,
@@ -203,7 +205,7 @@ impl ProofDLEQ {
     let expected_c = RistrettoScalar::from_bytes_mod_order_wide(&out);
 
     //verified = (expectedC == c)
-    return expected_c == self.c;
+    expected_c == self.c
   }
 
   fn compute_composites(
@@ -482,11 +484,17 @@ impl Server {
     let mut proof = None;
     if verifiable {
       let public_value = self.public_key.get_combined_pk_value(md)?;
-      proof = Some(ProofDLEQ::new(
+      /*proof = Some(ProofDLEQ::new(
         &tagged_key,
         &public_value.into(),
         &eval_point,
         &point,
+      ));*/
+      proof = Some(ProofDLEQ::new_batch(
+        &tagged_key,
+        &public_value.into(),
+        &[eval_point],
+        &[point],
       ));
     }
     Ok(Evaluation {
@@ -525,10 +533,15 @@ impl Client {
   ) -> bool {
     let Evaluation { output, proof } = eval;
     if let Ok(public_value) = public_key.get_combined_pk_value(md) {
-      return proof.as_ref().unwrap().verify(
+      /*return proof.as_ref().unwrap().verify(
         &public_value.into(),
         &output.decompress().unwrap(),
         &input.decompress().unwrap(),
+      );*/
+      return proof.as_ref().unwrap().verify_batch(
+        &public_value.into(),
+        &[output.decompress().unwrap()],
+        &[input.decompress().unwrap()],
       );
     }
     false


### PR DESCRIPTION
This PR fixes issue #82 by batching multiple client queries for the DLEQ ZKPs following the pseudo code from [draft-irtf-cfrg-voprf](https://cfrg.github.io/draft-irtf-cfrg-voprf/draft-irtf-cfrg-voprf.html#name-discrete-logarithm-equivale).