### PR TITLE
Remove unused subtle dependency.

### DIFF
--- a/sharks/Cargo.toml
+++ b/sharks/Cargo.toml
@@ -30,7 +30,6 @@ ff = { version = "0.13", features = ["derive"] }
 bitvec = { version = "1.0.1", default-features = false }
 byteorder = { version = "1", default-features = false }
 rand_core = { version = "0.6", default-features = false }
-subtle = { version = "2.4.1", default-features = false, features = ["i128"] }
 
 [dev-dependencies]
 criterion = "0.4"


### PR DESCRIPTION
We depend transitively on the `subtle` crate through the `ff` and `strobe-rs` (sharks) and `curve25519-dalek` (ppoprf) crates. And while we deal like `CtOption` as a return type, we don't need direct access to that crate's traits or symbols.

As such, the reference in sharks/Cargo.toml is unused; the crate is never referenced. It can be removed with no change in behaviour.