### PR TITLE
Clean up sharks from slice impl

### DIFF
--- a/sharks/src/share_ff.rs
+++ b/sharks/src/share_ff.rs
@@ -297,4 +297,9 @@ mod tests {
     ];
     let _ = Share::try_from(bytes.as_slice());
   }
+
+  #[test]
+  fn element_length() {
+      assert_eq!(FIELD_ELEMENT_LEN, std::mem::size_of::<Fp>());
+  }
 }

--- a/sharks/src/share_ff.rs
+++ b/sharks/src/share_ff.rs
@@ -152,7 +152,9 @@ impl core::convert::TryFrom<&[u8]> for Share {
 
   fn try_from(s: &[u8]) -> Result<Share, Self::Error> {
     if s.len() < FIELD_ELEMENT_LEN {
-      return Err("A Share must have enough bytes to represent a field element");
+      return Err(
+        "A Share must have enough bytes to represent a field element",
+      );
     }
     let xr = FpRepr(
       s[..FIELD_ELEMENT_LEN]
@@ -160,11 +162,10 @@ impl core::convert::TryFrom<&[u8]> for Share {
         // Slice into array only fails if the lengths don't match.
         // The length we pass is fixed, so this will not panic based
         // on the input data from the caller and unwrap is safe.
-        .expect("byte slice should be the right size for an x coordinate")
+        .expect("byte slice should be the right size for an x coordinate"),
     );
-    let x = Option::from(Fp::from_repr(xr)).ok_or(
-      "Failed to create field element from x representation"
-    )?;
+    let x = Option::from(Fp::from_repr(xr))
+      .ok_or("Failed to create field element from x representation")?;
 
     let y_bytes = &s[FIELD_ELEMENT_LEN..];
     let y_count = y_bytes.len() / FIELD_ELEMENT_LEN;
@@ -173,11 +174,10 @@ impl core::convert::TryFrom<&[u8]> for Share {
       let fr = FpRepr(
         y_bytes[i * FIELD_ELEMENT_LEN..(i + 1) * FIELD_ELEMENT_LEN]
           .try_into()
-          .expect("byte slice should be the right size for a y coordinate")
+          .expect("byte slice should be the right size for a y coordinate"),
       );
-      let f = Option::from(Fp::from_repr(fr)).ok_or(
-        "Failed to create field element from y representation"
-      )?;
+      let f = Option::from(Fp::from_repr(fr))
+        .ok_or("Failed to create field element from y representation")?;
       y.push(f);
     }
     Ok(Share { x, y })
@@ -275,19 +275,20 @@ mod tests {
 
   #[test]
   fn share_from_u8_slice_without_y_works() {
-    let share = Share::try_from(&get_test_bytes()[..FIELD_ELEMENT_LEN]).unwrap();
+    let share =
+      Share::try_from(&get_test_bytes()[..FIELD_ELEMENT_LEN]).unwrap();
     assert_eq!(share.x, fp_one());
     assert_eq!(share.y, vec![]);
   }
 
   #[test]
   fn share_from_u8_slice_partial_y_works() {
-    let share = Share::try_from(
-        &get_test_bytes()[..FIELD_ELEMENT_LEN + 20]).unwrap();
+    let share =
+      Share::try_from(&get_test_bytes()[..FIELD_ELEMENT_LEN + 20]).unwrap();
     assert_eq!(share.x, fp_one());
     assert_eq!(share.y, vec![]);
-    let share = Share::try_from(
-        &get_test_bytes()[..FIELD_ELEMENT_LEN*2 + 12]).unwrap();
+    let share =
+      Share::try_from(&get_test_bytes()[..FIELD_ELEMENT_LEN * 2 + 12]).unwrap();
     assert_eq!(share.x, fp_one());
     assert_eq!(share.y, vec![fp_two()]);
   }
@@ -321,6 +322,6 @@ mod tests {
 
   #[test]
   fn element_length() {
-      assert_eq!(FIELD_ELEMENT_LEN, std::mem::size_of::<Fp>());
+    assert_eq!(FIELD_ELEMENT_LEN, std::mem::size_of::<Fp>());
   }
 }

--- a/sharks/src/share_ff.rs
+++ b/sharks/src/share_ff.rs
@@ -272,6 +272,25 @@ mod tests {
   }
 
   #[test]
+  fn share_from_u8_slice_without_y_works() {
+    let share = Share::try_from(&get_test_bytes()[..FIELD_ELEMENT_LEN]).unwrap();
+    assert_eq!(share.x, fp_one());
+    assert_eq!(share.y, vec![]);
+  }
+
+  #[test]
+  fn share_from_u8_slice_partial_y_works() {
+    let share = Share::try_from(
+        &get_test_bytes()[..FIELD_ELEMENT_LEN + 20]).unwrap();
+    assert_eq!(share.x, fp_one());
+    assert_eq!(share.y, vec![]);
+    let share = Share::try_from(
+        &get_test_bytes()[..FIELD_ELEMENT_LEN*2 + 12]).unwrap();
+    assert_eq!(share.x, fp_one());
+    assert_eq!(share.y, vec![fp_two()]);
+  }
+
+  #[test]
   fn share_from_short_u8_slice_fails() {
     let bytes = get_test_bytes();
     assert!(Share::try_from(&bytes[0..FIELD_ELEMENT_LEN - 1]).is_err());


### PR DESCRIPTION
Improve the flow creating a `Share` from a byte slice after auditing unwrap() call sites.
    
- Use an early return on short input to save an indent level on the rest of the body.
- Document why the `expect` calls are appropriate, and write more specific panic messages for them.
- Split `Fp` parsing chains so they are easier to follow.
- Convert `CtOption` to `Option` which can be mapped to a `Result` so we can use the `?` operator instead of a guarded unwrap. This makes the `Err` wrapper on failure implicit, but I think it's worth not having unwrap calls at all.
- Remove unnecessary copy of the y coordinate bytes.
- Use a `y_count` variable instead of repeating the bytes/len division.

Add some extra tests to verify some assumptions.

The `y` vector could be collected from `y_bytes.chunks_exact()` for a more function style, but this requires a separate path for the `y_count = 0` case.
