### PR TITLE
Downgrade rand_core from 0.6.4 to 0.6.3

### DIFF
--- a/sta-rs/Cargo.toml
+++ b/sta-rs/Cargo.toml
@@ -12,7 +12,7 @@ strobe-rs = "0.8.1"
 strobe-rng = { path = "../strobe-rng" }
 adss-rs = { path = "../adss-rs" }
 ppoprf = { path = "../ppoprf" }
-rand_core = "0.6.4"
+rand_core = "0.6.3"
 zeroize = "1.5.7"
 
 [dev-dependencies]

--- a/sta-rs/test-utils/Cargo.toml
+++ b/sta-rs/test-utils/Cargo.toml
@@ -10,7 +10,7 @@ strobe-rs = "0.8.1"
 strobe-rng = { path = "../../strobe-rng" }
 sta-rs = { path = "../" }
 rand = { version = "0.8.5", features = [ "std" ] }
-rand_core = "0.6.4"
+rand_core = "0.6.3"
 rayon = "1.7"
 zipf = "7.0.0"
 ppoprf = { path = "../../ppoprf" }

--- a/strobe-rng/Cargo.toml
+++ b/strobe-rng/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2018"
 
 [dependencies]
 strobe-rs = "0.8.1"
-rand_core = "0.6.4"
+rand_core = "0.6.3"


### PR DESCRIPTION
Temporarily downgrading rand_core to avoid upgrading various dependencies in brave-core before we switch over to Chromium's Rust build system