### PR TITLE
Downgrade rand_core to 0.6.3, serde to 1.0.147, zeroize to 1.5.5

### DIFF
--- a/adss-rs/Cargo.toml
+++ b/adss-rs/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 strobe-rs = "0.8.1"
 strobe-rng = { path = "../strobe-rng" }
 rand = "0.8.5"
-zeroize = "1.5.7"
+zeroize = "1.5.5"
 
 [dependencies.sharks]
 default-features = true

--- a/ppoprf/Cargo.toml
+++ b/ppoprf/Cargo.toml
@@ -9,17 +9,17 @@ edition = "2018"
 
 [dependencies]
 rand = { version = "0.8.5", default-features = false }
-rand_core = { version = "0.6.4", features = [ "getrandom" ] }
+rand_core = { version = "0.6.3", features = [ "getrandom" ] }
 rand_core_ristretto = { version="0.5.1", package="rand_core" }
 bitvec = "1.0.1"
 curve25519-dalek =  { version = "3.2.0", features = [ "serde" ] }
-serde = "1.0.158"
+serde = "1.0.147"
 strobe-rs = "0.8.1"
 strobe-rng = { path = "../strobe-rng" }
 base64 = "0.20.0"
 bincode = "1.3.3"
 derive_more = "0.99"
-zeroize = { version = "1.5.7", features = [ "derive" ] }
+zeroize = { version = "1.5.5", features = [ "derive" ] }
 
 [dev-dependencies]
 criterion = "0.4.0"

--- a/sharks/Cargo.toml
+++ b/sharks/Cargo.toml
@@ -25,7 +25,7 @@ zeroize_memory = ["zeroize"]
 [dependencies]
 rand = { version = "0.8.5", default-features = false }
 arbitrary = { version = "1.3.0", features = ["derive"], optional = true }
-zeroize = { version = "1.5.7", features = ["zeroize_derive"], optional = true }
+zeroize = { version = "1.5.5", features = ["zeroize_derive"], optional = true }
 ff = { version = "0.13", features = ["derive"] }
 bitvec = { version = "1.0.1", default-features = false }
 byteorder = { version = "1", default-features = false }

--- a/sta-rs/Cargo.toml
+++ b/sta-rs/Cargo.toml
@@ -13,7 +13,7 @@ strobe-rng = { path = "../strobe-rng" }
 adss-rs = { path = "../adss-rs" }
 ppoprf = { path = "../ppoprf" }
 rand_core = "0.6.3"
-zeroize = "1.5.7"
+zeroize = "1.5.5"
 
 [dev-dependencies]
 criterion = "0.4.0"


### PR DESCRIPTION
For brave-core deployment, avoiding upgrading transitive dependencies until upstream Rust build system is used