### PR TITLE
Bump to 0.2.0 to fix PPOPRF minor version number, downgrade base64 to 0.13.0

### DIFF
--- a/adss-rs/Cargo.toml
+++ b/adss-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adss-rs"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["eV <ev@7pr.xyz>"]
 license = "MPL-2.0"
 edition = "2018"

--- a/ppoprf/Cargo.toml
+++ b/ppoprf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ppoprf"
-version = "0.0.1"
+version = "0.2.0"
 authors = ["Alex Davidson <coela@alxdavids.xyz>"]
 license = "MPL-2.0"
 edition = "2018"
@@ -16,7 +16,7 @@ curve25519-dalek =  { version = "3.2.0", features = [ "serde" ] }
 serde = "1.0.147"
 strobe-rs = "0.8.1"
 strobe-rng = { path = "../strobe-rng" }
-base64 = "0.20.0"
+base64 = "0.13.0"
 bincode = "1.3.3"
 derive_more = "0.99"
 zeroize = { version = "1.5.5", features = [ "derive" ] }

--- a/sta-rs/Cargo.toml
+++ b/sta-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sta-rs"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Alex Davidson <coela@alxdavids.xyz>"]
 license = "MPL-2.0"
 edition = "2018"

--- a/sta-rs/test-utils/Cargo.toml
+++ b/sta-rs/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sta-rs-test-utils"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/star-wasm/Cargo.toml
+++ b/star-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "star-wasm"
-version = "0.1.3"
+version = "0.2.0"
 authors = ["Rémi Berson <remi@brave.com>"]
 license = "MPL-2.0"
 edition = "2018"

--- a/strobe-rng/Cargo.toml
+++ b/strobe-rng/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strobe-rng"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["eV <ev@7pr.xyz>"]
 license = "MPL-2.0"
 edition = "2018"


### PR DESCRIPTION
the new upstream build system in chromium does not allow minor version numbers to be 0

downgrading base64 to prevent dependency duplication in core