### PR TITLE
adss: Use OsRng from rand_core

### DIFF
--- a/adss-rs/Cargo.toml
+++ b/adss-rs/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2018"
 [dependencies]
 strobe-rs = "0.8.1"
 strobe-rng = { path = "../strobe-rng" }
-rand = "0.8.5"
 zeroize = "1.5.5"
+rand_core = { version = "0.6.3", features = ["getrandom"] }
 
 [dependencies.sharks]
 default-features = false

--- a/adss-rs/src/lib.rs
+++ b/adss-rs/src/lib.rs
@@ -237,7 +237,7 @@ impl Commune {
     let mut K_vec: Vec<u8> = K.to_vec();
     K_vec.extend(vec![0u8; 16]);
     let polys = Sharks::from(self.A.clone()).dealer_rng(&K_vec, &mut L)?;
-    let S = polys.gen(&mut rand::rngs::OsRng);
+    let S = polys.gen(&mut rand_core::OsRng);
     Ok(Share {
       A: self.A.clone(),
       S,


### PR DESCRIPTION
Use the system random number generator instead of the thead-local one. This is slower, but may address concerns about thread-safety over ffi. Tie to the same `rand_core` minimum version as the the other crates in the repo.