### PR TITLE
Prefer rand to rand_core

### DIFF
--- a/ppoprf/Cargo.toml
+++ b/ppoprf/Cargo.toml
@@ -8,9 +8,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rand = { version = "0.8.5", default-features = false }
-rand_core = { version = "0.6.3", features = [ "getrandom" ] }
-rand_core_ristretto = { version="0.5.1", package="rand_core" }
+rand = { version = "0.8.5", features = [ "getrandom" ] }
+rand_core_ristretto = { version="0.5.1", package="rand_core", default-features = false }
 bitvec = "1.0.1"
 curve25519-dalek =  { version = "3.2.0", features = [ "serde" ] }
 serde = "1.0.147"

--- a/ppoprf/benches/bench.rs
+++ b/ppoprf/benches/bench.rs
@@ -1,7 +1,8 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 
 use curve25519_dalek::ristretto::RistrettoPoint;
-use rand_core::{OsRng as PRNG, RngCore};
+use rand::rngs::OsRng as PRNG;
+use rand::Rng;
 use rand_core_ristretto::OsRng;
 
 use ppoprf::ggm::GGM;
@@ -115,7 +116,7 @@ fn benchmark_server(c: &mut Criterion) {
 fn benchmark_client(c: &mut Criterion) {
   let mds: Vec<u8> = (0..=7).collect();
   let mut input = [0u8; 32];
-  PRNG.fill_bytes(&mut input);
+  PRNG.fill(&mut input);
   let server = Server::new(mds.clone()).unwrap();
 
   c.bench_function("Client blind", |b| {

--- a/ppoprf/src/ggm.rs
+++ b/ppoprf/src/ggm.rs
@@ -7,7 +7,8 @@ use std::fmt;
 
 use super::{PPRFError, PPRF};
 use bitvec::prelude::*;
-use rand_core::{OsRng, RngCore};
+use rand::rngs::OsRng;
+use rand::RngCore;
 use strobe_rng::StrobeRng;
 use strobe_rs::{SecParam, Strobe};
 

--- a/ppoprf/src/ggm.rs
+++ b/ppoprf/src/ggm.rs
@@ -8,7 +8,7 @@ use std::fmt;
 use super::{PPRFError, PPRF};
 use bitvec::prelude::*;
 use rand::rngs::OsRng;
-use rand::RngCore;
+use rand::Rng;
 use strobe_rng::StrobeRng;
 use strobe_rs::{SecParam, Strobe};
 
@@ -46,7 +46,7 @@ impl GGMPseudorandomGenerator {
     t.key(&sample_secret(), false);
     let mut rng: StrobeRng = t.into();
     let mut s_key = [0u8; 32];
-    rng.fill_bytes(&mut s_key);
+    rng.fill(&mut s_key);
     GGMPseudorandomGenerator { key: s_key }
   }
 
@@ -55,7 +55,7 @@ impl GGMPseudorandomGenerator {
     t.key(&self.key, false);
     t.ad(input, false);
     let mut rng: StrobeRng = t.into();
-    rng.fill_bytes(output);
+    rng.fill(output);
   }
 }
 
@@ -220,7 +220,7 @@ impl PPRF for GGM {
 
 fn sample_secret() -> Vec<u8> {
   let mut out = vec![0u8; 32];
-  OsRng.fill_bytes(&mut out);
+  OsRng.fill(out.as_mut_slice());
   out
 }
 

--- a/ppoprf/src/ppoprf.rs
+++ b/ppoprf/src/ppoprf.rs
@@ -13,9 +13,8 @@
 
 extern crate rand;
 
-extern crate rand_core;
 use curve25519_dalek::traits::Identity;
-use rand_core::RngCore;
+use rand::Rng;
 use rand_core_ristretto::OsRng;
 
 use curve25519_dalek::constants::RISTRETTO_BASEPOINT_POINT;
@@ -439,7 +438,7 @@ fn strobe_hash(input: &[u8], label: &str, out: &mut [u8]) {
   let mut t = Strobe::new(label.as_bytes(), SecParam::B128);
   t.key(input, false);
   let mut rng: StrobeRng = t.into();
-  rng.fill_bytes(out);
+  rng.fill(out);
 }
 
 #[cfg(test)]

--- a/sharks/Cargo.toml
+++ b/sharks/Cargo.toml
@@ -29,7 +29,6 @@ zeroize = { version = "1.5.5", features = ["zeroize_derive"], optional = true }
 ff = { version = "0.13", features = ["derive"] }
 bitvec = { version = "1.0.1", default-features = false }
 byteorder = { version = "1", default-features = false }
-rand_core = { version = "0.6", default-features = false }
 
 [dev-dependencies]
 criterion = "0.4"

--- a/sta-rs/Cargo.toml
+++ b/sta-rs/Cargo.toml
@@ -12,7 +12,7 @@ strobe-rs = "0.8.1"
 strobe-rng = { path = "../strobe-rng" }
 adss-rs = { path = "../adss-rs" }
 ppoprf = { path = "../ppoprf" }
-rand_core = "0.6.3"
+rand = "0.8.5"
 zeroize = "1.5.5"
 
 [dev-dependencies]

--- a/sta-rs/src/lib.rs
+++ b/sta-rs/src/lib.rs
@@ -108,7 +108,7 @@
 use std::error::Error;
 use std::str;
 
-use rand::RngCore;
+use rand::Rng;
 use strobe_rng::StrobeRng;
 use strobe_rs::{SecParam, Strobe};
 use zeroize::{Zeroize, ZeroizeOnDrop};
@@ -502,5 +502,5 @@ pub fn strobe_digest(key: &[u8], ad: &[&[u8]], label: &str, out: &mut [u8]) {
     t.ad(x, false);
   }
   let mut rng: StrobeRng = t.into();
-  rng.fill_bytes(out);
+  rng.fill(out);
 }

--- a/sta-rs/src/lib.rs
+++ b/sta-rs/src/lib.rs
@@ -108,7 +108,7 @@
 use std::error::Error;
 use std::str;
 
-use rand_core::RngCore;
+use rand::RngCore;
 use strobe_rng::StrobeRng;
 use strobe_rs::{SecParam, Strobe};
 use zeroize::{Zeroize, ZeroizeOnDrop};

--- a/sta-rs/test-utils/Cargo.toml
+++ b/sta-rs/test-utils/Cargo.toml
@@ -10,7 +10,6 @@ strobe-rs = "0.8.1"
 strobe-rng = { path = "../../strobe-rng" }
 sta-rs = { path = "../" }
 rand = { version = "0.8.5", features = [ "std" ] }
-rand_core = "0.6.3"
 rayon = "1.7"
 zipf = "7.0.0"
 ppoprf = { path = "../../ppoprf" }


### PR DESCRIPTION
As mentioned in https://github.com/brave/sta-rs/pull/241#issuecomment-1517294088 crate docs [recommend](https://docs.rs/rand_core/latest/rand_core/) using traits from `rand` over `rand_core` except when actually implementing a generator. Do so.

I've left usage in `strobe-rng` since that's clearly low-level. Some other usage like `ppoprf::ggm` is ambiguous.