### PR TITLE
Bump MSRV to 1.60.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        rust: [1.59.0, stable]
+        rust: [1.60.0, stable]
         os: [ubuntu-20.04]
 
     env:


### PR DESCRIPTION
Raise the minimum-supported Rust version to 1.60.0. This is required by the bumpalo 3.12.1 dependency, which fixes a soundness bug.

Brave browser is on `1.67.0` so this is fine for our current deployment.