### PR TITLE
ppoprf: Disable spurious clippy warning

### DIFF
--- a/ppoprf/src/ggm.rs
+++ b/ppoprf/src/ggm.rs
@@ -178,6 +178,8 @@ impl PPRF for GGM {
     self.partial_eval(&mut input_bits, output)
   }
 
+  // Disable clippy lint false positive on `iter_bv` with Rust 1.70.0.
+  #[allow(clippy::redundant_clone)]
   fn puncture(&mut self, input: &[u8]) -> Result<(), PPRFError> {
     if input.len() != self.inp_len {
       return Err(PPRFError::BadInputLength {


### PR DESCRIPTION
With Rust 1.70.0 `clippy` started warning about a redundant clone on the `iter_bv` temporary in `puncture`. This seems to be incorrect since the variable can in fact be updated throughout the loop.

Disable the lint so continuous integration runs are clean.