### PR TITLE
Remove unsound atty transitive dependency

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        rust: [1.60.0, stable]
+        rust: [1.64.0, stable]
         os: [ubuntu-20.04]
 
     env:

--- a/ppoprf/Cargo.toml
+++ b/ppoprf/Cargo.toml
@@ -22,7 +22,7 @@ zeroize = { version = "1.5.5", features = [ "derive" ] }
 
 [dev-dependencies]
 criterion = "0.4.0"
-env_logger = "0.9.3"
+env_logger = "0.10.0"
 log = "0.4.17"
 reqwest = { version = "0.11.18", features = [ "blocking", "json" ] }
 dotenvy = "0.15.7"

--- a/ppoprf/Cargo.toml
+++ b/ppoprf/Cargo.toml
@@ -21,7 +21,7 @@ derive_more = "0.99"
 zeroize = { version = "1.5.5", features = [ "derive" ] }
 
 [dev-dependencies]
-criterion = "0.4.0"
+criterion = "0.5.1"
 env_logger = "0.10.0"
 log = "0.4.17"
 reqwest = { version = "0.11.18", features = [ "blocking", "json" ] }

--- a/sharks/Cargo.toml
+++ b/sharks/Cargo.toml
@@ -31,7 +31,7 @@ bitvec = { version = "1.0.1", default-features = false }
 byteorder = { version = "1", default-features = false }
 
 [dev-dependencies]
-criterion = "0.4"
+criterion = "0.5"
 rand_chacha = "0.3"
 
 [[bench]]

--- a/sta-rs/Cargo.toml
+++ b/sta-rs/Cargo.toml
@@ -16,7 +16,7 @@ rand = "0.8.5"
 zeroize = "1.5.5"
 
 [dev-dependencies]
-criterion = "0.4.0"
+criterion = "0.5.1"
 sta-rs-test-utils = { path = "./test-utils" }
 rand = { version = "0.8.5", features = [ "std" ] }
 


### PR DESCRIPTION
Bump `env_logger` and `criterion` dev-dependencies to address [RUSTSEC-2021-0145](https://rustsec.org/advisories/RUSTSEC-2021-0145).