### PR TITLE
Publish star 0.2.1

### DIFF
--- a/star/Cargo.toml
+++ b/star/Cargo.toml
@@ -24,7 +24,7 @@ star-test-utils = { path = "./test-utils" }
 rand = { version = "0.8.5", features = [ "std" ] }
 
 [features]
-star2 = ["star-test-utils/star2"]
+star2 = []
 
 [[bench]]
 name = "bench"

--- a/star/Cargo.toml
+++ b/star/Cargo.toml
@@ -12,8 +12,8 @@ edition = "2018"
 
 [dependencies]
 strobe-rs = "0.8.1"
-adss = { path = "../adss" }
-ppoprf = { path = "../ppoprf" }
+adss = { path = "../adss", version = "0.2.1" }
+ppoprf = { path = "../ppoprf", version = "0.3.0" }
 rand = "0.8.5"
 rand_core = "0.6.4"
 zeroize = "1.5.5"

--- a/star/benches/bench.rs
+++ b/star/benches/bench.rs
@@ -4,6 +4,8 @@ use criterion::{
 };
 use rand::Rng;
 
+#[cfg(feature = "star2")]
+use ppoprf::ppoprf::Server as PPOPRFServer;
 use star::{AssociatedData, Message};
 use star_test_utils::*;
 

--- a/star/src/lib.rs
+++ b/star/src/lib.rs
@@ -277,8 +277,6 @@ impl Message {
     rnd: &[u8; 32],
     aux: Option<AssociatedData>,
   ) -> Result<Self, Box<dyn Error>> {
-    // Adding '_' in as prefix of 'oprf' because when star2 is
-    // disabled then Clippy complains.
     let r = mg.derive_random_values(rnd);
 
     // key is then used for encrypting measurement and associated

--- a/star/test-utils/Cargo.toml
+++ b/star/test-utils/Cargo.toml
@@ -12,6 +12,3 @@ rand = { version = "0.8.5", features = [ "std" ] }
 rayon = "1.7"
 zipf = "7.0.0"
 ppoprf = { path = "../../ppoprf" }
-
-[features]
-star2 = ["star/star2"]

--- a/star/test-utils/src/lib.rs
+++ b/star/test-utils/src/lib.rs
@@ -7,12 +7,6 @@ use rayon::prelude::*;
 
 use zipf::ZipfDistribution;
 
-#[cfg(feature = "star2")]
-pub use ppoprf::ppoprf::Server as PPOPRFServer;
-
-#[cfg(not(feature = "star2"))]
-pub struct PPOPRFServer;
-
 use star::*;
 
 // The `zipf_measurement` function returns a client `Measurement` sampled from


### PR DESCRIPTION
Remove the `star2` feature from `star-test-utils`. This seems to weaken the dev-dependency link enough that the package can be published to crates.io.

The `star2` feature hasn't compiled for a while, and this doesn't address #68, but it should allow publication and downstream use as we've been doing.