### PR TITLE
Revert to sta-rs crate name

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ change substantially in future versions.
 
 ## Crates
 
-- [star](./star): A rust implementation of the [STAR
+- [sta-rs](./star): A rust implementation of the [STAR
   protocol](https://arxiv.org/abs/2109.10074).
 - [ppoprf](./ppoprf): A rust implementation of the PPOPRF protocol
   detailed in the [STAR paper](https://arxiv.org/abs/2109.10074).

--- a/star-wasm/Cargo.toml
+++ b/star-wasm/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "rlib"]
 default = []
 
 [dependencies]
-star = { path = "../star", default-features = false }
+sta-rs = { path = "../star", default-features = false }
 getrandom = { version = "0.2", features = ["js"] }
 wasm-bindgen = "0.2"
 base64 = "0.20"

--- a/star-wasm/src/lib.rs
+++ b/star-wasm/src/lib.rs
@@ -9,7 +9,7 @@ use wasm_bindgen::prelude::*;
 
 use base64::{decode, encode};
 
-use star::{
+use sta_rs::{
   derive_ske_key, share_recover, MessageGenerator, Share, SingleMeasurement,
   WASMSharingMaterial,
 };

--- a/star/Cargo.toml
+++ b/star/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "star"
+name = "sta-rs"
 version = "0.2.1"
 authors = ["Alex Davidson <coela@alxdavids.xyz>"]
 description = "Distributed Secret-Sharing for Threshold Aggregation Reporting"

--- a/star/README.md
+++ b/star/README.md
@@ -1,4 +1,4 @@
-# star crate
+# sta-rs crate
 
 Rust implementation of the [STAR
 protocol](https://arxiv.org/abs/2109.10074). Consists of client API

--- a/star/benches/bench.rs
+++ b/star/benches/bench.rs
@@ -6,7 +6,7 @@ use rand::Rng;
 
 #[cfg(feature = "star2")]
 use ppoprf::ppoprf::Server as PPOPRFServer;
-use star::{AssociatedData, Message};
+use sta_rs::{AssociatedData, Message};
 use star_test_utils::*;
 
 fn criterion_benchmark(c: &mut Criterion) {

--- a/star/src/lib.rs
+++ b/star/src/lib.rs
@@ -33,7 +33,7 @@
 //! share, tag)`. This message can then be sent to the aggregation server.
 //!
 //! ```
-//! # use star::*;
+//! # use sta_rs::*;
 //! # let threshold = 2;
 //! # let epoch = "t";
 //! let measurement = SingleMeasurement::new("hello world".as_bytes());
@@ -63,7 +63,7 @@
 //! tag)` is then sent to the server.
 //!
 //! ```
-//! # use star::*;
+//! # use sta_rs::*;
 //! # let threshold = 2;
 //! # let epoch = "t";
 //! let measurement = SingleMeasurement::new("hello world".as_bytes());
@@ -85,7 +85,7 @@
 //! possible to recover the randomness encoded in each of the shares
 //!
 //! ```
-//! # use star::*;
+//! # use sta_rs::*;
 //! # use star_test_utils::*;
 //! # let mut messages = Vec::new();
 //! # let threshold = 2;

--- a/star/test-utils/Cargo.toml
+++ b/star/test-utils/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 strobe-rs = "0.8.1"
-star = { path = "../" }
+sta-rs = { path = "../" }
 rand = { version = "0.8.5", features = [ "std" ] }
 rayon = "1.7"
 zipf = "7.0.0"

--- a/star/test-utils/src/lib.rs
+++ b/star/test-utils/src/lib.rs
@@ -7,7 +7,7 @@ use rayon::prelude::*;
 
 use zipf::ZipfDistribution;
 
-use star::*;
+use sta_rs::*;
 
 // The `zipf_measurement` function returns a client `Measurement` sampled from
 // Zipf power-law distribution with `n` corresponding to the number

--- a/star/tests/e2e.rs
+++ b/star/tests/e2e.rs
@@ -1,4 +1,4 @@
-use star::*;
+use sta_rs::*;
 use star_test_utils::*;
 
 #[cfg(feature = "star2")]


### PR DESCRIPTION
It turns out there's already a crate [published](https://crates.io/crates/star) as `star` on crates.io (a simple tar file format implementation).

Revert to our earlier `sta-rs` to avoid the name collision.