### PR TITLE
Fix sharks no_std build

### DIFF
--- a/.github/workflows/nostd.yml
+++ b/.github/workflows/nostd.yml
@@ -1,0 +1,37 @@
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+name: Tests (nostd)
+
+jobs:
+  test-nofeatures:
+    name: ${{matrix.rust}} on ${{matrix.os}}
+    runs-on: ${{matrix.os}}
+
+    strategy:
+      matrix:
+        rust: [1.64.0, stable]
+        os: [ubuntu-20.04]
+
+    env:
+      RUSTFLAGS: ''
+      CARGO_PROFILE_DEV_DEBUG: '0' # reduce size of target directory
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Toolchain
+        uses: dtolnay/rust-toolchain@${{matrix.rust}}
+
+      - name: Cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Check
+        run: cargo check --no-default-features --all-targets
+
+      - name: Test
+        run: cargo test --no-default-features

--- a/.github/workflows/nostd.yml
+++ b/.github/workflows/nostd.yml
@@ -36,4 +36,4 @@ jobs:
         run: cargo check --no-default-features --all-targets
 
       - name: Test
-        run: cargo test --no-default-features
+        run: cargo test --release --no-default-features

--- a/.github/workflows/nostd.yml
+++ b/.github/workflows/nostd.yml
@@ -25,7 +25,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Toolchain
-        uses: dtolnay/rust-toolchain@${{matrix.rust}}
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{matrix.rust}}
 
       - name: Cache
         uses: Swatinem/rust-cache@v2

--- a/sharks/benches/benchmarks.rs
+++ b/sharks/benches/benchmarks.rs
@@ -1,10 +1,11 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use std::convert::TryFrom;
 
-use star_sharks::{Share, Sharks};
+use star_sharks::Share;
 
+#[cfg(feature = "std")]
 fn dealer(c: &mut Criterion) {
-  let sharks = Sharks(255);
+  let sharks = star_sharks::Sharks(255);
   let mut dealer = sharks.dealer(&[1]).unwrap();
 
   c.bench_function("obtain_shares_dealer", |b| {
@@ -13,8 +14,9 @@ fn dealer(c: &mut Criterion) {
   c.bench_function("step_shares_dealer", |b| b.iter(|| dealer.next()));
 }
 
+#[cfg(feature = "std")]
 fn recover(c: &mut Criterion) {
-  let sharks = Sharks(255);
+  let sharks = star_sharks::Sharks(255);
   let dealer = sharks.dealer(&[1]).unwrap();
   let shares: Vec<Share> = dealer.take(255).collect();
 
@@ -24,7 +26,7 @@ fn recover(c: &mut Criterion) {
 }
 
 fn share(c: &mut Criterion) {
-  let bytes_vec = get_test_bytes();
+  let bytes_vec = test_bytes();
   let bytes = bytes_vec.as_slice();
   let share = Share::try_from(bytes).unwrap();
 
@@ -37,7 +39,7 @@ fn share(c: &mut Criterion) {
   });
 }
 
-fn get_test_bytes() -> Vec<u8> {
+fn test_bytes() -> Vec<u8> {
   let suffix = vec![0u8; star_sharks::FIELD_ELEMENT_LEN - 1];
   let mut bytes = vec![1u8; 1];
   bytes.extend(suffix.clone()); // x coord
@@ -48,5 +50,10 @@ fn get_test_bytes() -> Vec<u8> {
   bytes
 }
 
+#[cfg(feature = "std")]
 criterion_group!(benches, dealer, recover, share);
+
+#[cfg(not(feature = "std"))]
+criterion_group!(benches, share);
+
 criterion_main!(benches);

--- a/sharks/src/lib.rs
+++ b/sharks/src/lib.rs
@@ -184,7 +184,7 @@ mod tests {
   }
 
   #[test]
-  fn test_insufficient_shares_err() {
+  fn insufficient_shares() {
     let sharks = Sharks(500);
     let shares: Vec<Share> = sharks
       .make_shares(&fp_one_repr())
@@ -196,7 +196,7 @@ mod tests {
   }
 
   #[test]
-  fn test_duplicate_shares_err() {
+  fn duplicate_shares() {
     let sharks = Sharks(500);
     let mut shares: Vec<Share> = sharks
       .make_shares(&fp_one_repr())
@@ -212,7 +212,7 @@ mod tests {
   }
 
   #[test]
-  fn test_integration_works() {
+  fn integration() {
     let sharks = Sharks(500);
     let mut input = Vec::new();
     input.extend(fp_one_repr());
@@ -227,7 +227,7 @@ mod tests {
 
   use core::iter;
   #[test]
-  fn test_integration_works_random() {
+  fn integration_random() {
     let sharks = Sharks(40);
     let mut rng = rand::thread_rng();
     let mut input = Vec::new();

--- a/sharks/src/lib.rs
+++ b/sharks/src/lib.rs
@@ -222,7 +222,7 @@ mod tests {
     let shares: Vec<Share> =
       sharks.make_shares(&input).unwrap().take(500).collect();
     let secret = sharks.recover(&shares).unwrap();
-    assert_eq!(secret, get_test_bytes());
+    assert_eq!(secret, test_bytes());
   }
 
   use core::iter;
@@ -241,10 +241,10 @@ mod tests {
       .collect();
     //let shares: Vec<Share> = sharks.make_shares(&[1, 2, 3, 4]).unwrap().take(255).collect();
     let secret = sharks.recover(&shares).unwrap();
-    assert_eq!(secret, get_test_bytes());
+    assert_eq!(secret, test_bytes());
   }
 
-  fn get_test_bytes() -> Vec<u8> {
+  fn test_bytes() -> Vec<u8> {
     let suffix = vec![0u8; FIELD_ELEMENT_LEN - 1];
     let mut bytes = vec![1u8; 1];
     bytes.extend(suffix.clone()); // x coord
@@ -260,7 +260,7 @@ mod tests {
   #[test]
   fn zero_threshold() {
     let sharks = Sharks(0);
-    let testcase = Share::try_from(get_test_bytes().as_slice()).unwrap();
+    let testcase = Share::try_from(test_bytes().as_slice()).unwrap();
     let secret = sharks.recover(&vec![testcase]);
     assert!(secret.is_err());
   }

--- a/sharks/src/lib.rs
+++ b/sharks/src/lib.rs
@@ -5,7 +5,7 @@
 
 extern crate alloc;
 
-// implement operations using a larger finite field as well
+// implement operations using a larger finite field
 extern crate ff;
 mod share_ff;
 
@@ -19,7 +19,8 @@ pub use share_ff::Share;
 pub use share_ff::{get_evaluator, interpolate, random_polynomial};
 pub use share_ff::{Fp, FpRepr, FIELD_ELEMENT_LEN};
 
-/// Tuple struct which implements methods to generate shares and recover secrets over a 256 bits Galois Field.
+/// Tuple struct which implements methods to generate shares
+/// and recover secrets over a finite field.
 /// Its only parameter is the minimum shares threshold.
 pub struct Sharks(pub u32);
 

--- a/sharks/src/share_ff.rs
+++ b/sharks/src/share_ff.rs
@@ -135,7 +135,9 @@ impl From<&Share> for Vec<u8> {
     let mut bytes = Vec::with_capacity((s.y.len() + 1) * FIELD_ELEMENT_LEN);
     let repr = s.x.to_repr();
     let x_coord = repr.as_ref().to_vec();
-    let y_coords = s.y.iter()
+    let y_coords = s
+      .y
+      .iter()
       .map(|p| p.to_repr().as_ref().to_vec())
       .fold(Vec::new(), |acc, r| [acc, r.to_vec()].concat());
     bytes.extend(x_coord);
@@ -231,7 +233,8 @@ mod tests {
   fn evaluation() {
     let iter =
       get_evaluator(vec![vec![fp_three(), fp_two(), fp_three() + fp_two()]]);
-    let values: Vec<(Fp, Vec<Fp>)> = iter.take(2).map(|s| (s.x, s.y)).collect();
+    let values: Vec<(Fp, Vec<Fp>)> =
+      iter.take(2).map(|s| (s.x, s.y)).collect();
     assert_eq!(
       values,
       vec![
@@ -273,8 +276,7 @@ mod tests {
 
   #[test]
   fn share_from_u8_slice_without_y() {
-    let share =
-      Share::try_from(&test_bytes()[..FIELD_ELEMENT_LEN]).unwrap();
+    let share = Share::try_from(&test_bytes()[..FIELD_ELEMENT_LEN]).unwrap();
     assert_eq!(share.x, fp_one());
     assert_eq!(share.y, vec![]);
   }
@@ -320,6 +322,6 @@ mod tests {
 
   #[test]
   fn element_length() {
-    assert_eq!(FIELD_ELEMENT_LEN, std::mem::size_of::<Fp>());
+    assert_eq!(FIELD_ELEMENT_LEN, core::mem::size_of::<Fp>());
   }
 }

--- a/sharks/src/share_ff.rs
+++ b/sharks/src/share_ff.rs
@@ -233,8 +233,7 @@ mod tests {
   fn evaluation() {
     let iter =
       get_evaluator(vec![vec![fp_three(), fp_two(), fp_three() + fp_two()]]);
-    let values: Vec<(Fp, Vec<Fp>)> =
-      iter.take(2).map(|s| (s.x, s.y)).collect();
+    let values: Vec<(Fp, Vec<Fp>)> = iter.take(2).map(|s| (s.x, s.y)).collect();
     assert_eq!(
       values,
       vec![

--- a/sharks/src/share_ff.rs
+++ b/sharks/src/share_ff.rs
@@ -260,13 +260,13 @@ mod tests {
       y: vec![fp_two(), fp_three()],
     };
     let bytes = Vec::from(&share);
-    let chk_bytes = get_test_bytes();
+    let chk_bytes = test_bytes();
     assert_eq!(bytes, chk_bytes);
   }
 
   #[test]
   fn share_from_u8_slice() {
-    let share = Share::try_from(&get_test_bytes()[..]).unwrap();
+    let share = Share::try_from(&test_bytes()[..]).unwrap();
     assert_eq!(share.x, fp_one());
     assert_eq!(share.y, vec![fp_two(), fp_three()]);
   }
@@ -274,7 +274,7 @@ mod tests {
   #[test]
   fn share_from_u8_slice_without_y() {
     let share =
-      Share::try_from(&get_test_bytes()[..FIELD_ELEMENT_LEN]).unwrap();
+      Share::try_from(&test_bytes()[..FIELD_ELEMENT_LEN]).unwrap();
     assert_eq!(share.x, fp_one());
     assert_eq!(share.y, vec![]);
   }
@@ -282,23 +282,23 @@ mod tests {
   #[test]
   fn share_from_u8_slice_partial_y() {
     let share =
-      Share::try_from(&get_test_bytes()[..FIELD_ELEMENT_LEN + 20]).unwrap();
+      Share::try_from(&test_bytes()[..FIELD_ELEMENT_LEN + 20]).unwrap();
     assert_eq!(share.x, fp_one());
     assert_eq!(share.y, vec![]);
     let share =
-      Share::try_from(&get_test_bytes()[..FIELD_ELEMENT_LEN * 2 + 12]).unwrap();
+      Share::try_from(&test_bytes()[..FIELD_ELEMENT_LEN * 2 + 12]).unwrap();
     assert_eq!(share.x, fp_one());
     assert_eq!(share.y, vec![fp_two()]);
   }
 
   #[test]
   fn share_from_short_u8_slice() {
-    let bytes = get_test_bytes();
+    let bytes = test_bytes();
     assert!(Share::try_from(&bytes[0..FIELD_ELEMENT_LEN - 1]).is_err());
     assert!(Share::try_from(&bytes[0..1]).is_err());
   }
 
-  fn get_test_bytes() -> Vec<u8> {
+  fn test_bytes() -> Vec<u8> {
     let suffix = vec![0u8; FIELD_ELEMENT_LEN - 1];
     let mut bytes = vec![1u8; 1];
     bytes.extend(suffix.clone()); // x coord

--- a/sharks/src/share_ff.rs
+++ b/sharks/src/share_ff.rs
@@ -132,12 +132,10 @@ pub struct Share {
 /// Obtains a byte vector from a `Share` instance
 impl From<&Share> for Vec<u8> {
   fn from(s: &Share) -> Vec<u8> {
-    let mut bytes: Vec<u8> = Vec::with_capacity(s.y.len() + FIELD_ELEMENT_LEN);
+    let mut bytes = Vec::with_capacity(s.y.len() + FIELD_ELEMENT_LEN);
     let repr = s.x.to_repr();
     let x_coord = repr.as_ref().to_vec();
-    let y_coords: Vec<u8> = s
-      .y
-      .iter()
+    let y_coords = s.y.iter()
       .map(|p| p.to_repr().as_ref().to_vec())
       .fold(Vec::new(), |acc, r| [acc, r.to_vec()].concat());
     bytes.extend(x_coord);

--- a/sharks/src/share_ff.rs
+++ b/sharks/src/share_ff.rs
@@ -184,7 +184,7 @@ impl core::convert::TryFrom<&[u8]> for Share {
 
 #[cfg(test)]
 mod tests {
-  use super::{get_evaluator, interpolate, random_polynomial};
+  use super::{get_evaluator, interpolate};
   use super::{Fp, Share, FIELD_ELEMENT_LEN};
   use crate::ff::Field;
   use alloc::{vec, vec::Vec};
@@ -220,15 +220,15 @@ mod tests {
   }
 
   #[test]
-  fn random_polynomial_works() {
+  fn random_polynomial() {
     let mut rng = rand_chacha::ChaCha8Rng::from_seed([0x90; 32]);
-    let poly = random_polynomial(fp_one(), 3, &mut rng);
+    let poly = super::random_polynomial(fp_one(), 3, &mut rng);
     assert_eq!(poly.len(), 3);
     assert_eq!(poly[2], fp_one());
   }
 
   #[test]
-  fn evaluator_works() {
+  fn evaluation() {
     let iter =
       get_evaluator(vec![vec![fp_three(), fp_two(), fp_three() + fp_two()]]);
     let values: Vec<(Fp, Vec<Fp>)> = iter.take(2).map(|s| (s.x, s.y)).collect();
@@ -242,9 +242,9 @@ mod tests {
   }
 
   #[test]
-  fn interpolate_works() {
+  fn interpolation() {
     let mut rng = rand_chacha::ChaCha8Rng::from_seed([0x90; 32]);
-    let poly = random_polynomial(fp_one(), 5, &mut rng);
+    let poly = super::random_polynomial(fp_one(), 5, &mut rng);
     let iter = get_evaluator(vec![poly]);
     let shares: Vec<Share> = iter.take(5).collect();
     let root = interpolate(&shares).unwrap();
@@ -254,7 +254,7 @@ mod tests {
   }
 
   #[test]
-  fn vec_from_share_works() {
+  fn vec_from_share() {
     let share = Share {
       x: fp_one(),
       y: vec![fp_two(), fp_three()],
@@ -265,14 +265,14 @@ mod tests {
   }
 
   #[test]
-  fn share_from_u8_slice_works() {
+  fn share_from_u8_slice() {
     let share = Share::try_from(&get_test_bytes()[..]).unwrap();
     assert_eq!(share.x, fp_one());
     assert_eq!(share.y, vec![fp_two(), fp_three()]);
   }
 
   #[test]
-  fn share_from_u8_slice_without_y_works() {
+  fn share_from_u8_slice_without_y() {
     let share =
       Share::try_from(&get_test_bytes()[..FIELD_ELEMENT_LEN]).unwrap();
     assert_eq!(share.x, fp_one());
@@ -280,7 +280,7 @@ mod tests {
   }
 
   #[test]
-  fn share_from_u8_slice_partial_y_works() {
+  fn share_from_u8_slice_partial_y() {
     let share =
       Share::try_from(&get_test_bytes()[..FIELD_ELEMENT_LEN + 20]).unwrap();
     assert_eq!(share.x, fp_one());
@@ -292,7 +292,7 @@ mod tests {
   }
 
   #[test]
-  fn share_from_short_u8_slice_fails() {
+  fn share_from_short_u8_slice() {
     let bytes = get_test_bytes();
     assert!(Share::try_from(&bytes[0..FIELD_ELEMENT_LEN - 1]).is_err());
     assert!(Share::try_from(&bytes[0..1]).is_err());

--- a/sharks/src/share_ff.rs
+++ b/sharks/src/share_ff.rs
@@ -132,7 +132,7 @@ pub struct Share {
 /// Obtains a byte vector from a `Share` instance
 impl From<&Share> for Vec<u8> {
   fn from(s: &Share) -> Vec<u8> {
-    let mut bytes = Vec::with_capacity(s.y.len() + FIELD_ELEMENT_LEN);
+    let mut bytes = Vec::with_capacity((s.y.len() + 1) * FIELD_ELEMENT_LEN);
     let repr = s.x.to_repr();
     let x_coord = repr.as_ref().to_vec();
     let y_coords = s.y.iter()


### PR DESCRIPTION
Various minor fixes for the `star-sharks` crate

- Fix `no_std` build (`--no-default-features`)
- Add `no_std` ci job so it doesn't break again
- Shorten test names and comments
- Fix `Share::from` preallocation calculation
- Remove some unnecessary type declarations