### PR TITLE
Reduce renovate noise

### DIFF
--- a/.github/workflows/nostd.yml
+++ b/.github/workflows/nostd.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        rust: [1.64.0, stable]
+        rust: [1.70.0, stable]
         os: [ubuntu-20.04]
 
     env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        rust: [1.64.0, stable]
+        rust: [1.70.0, stable]
         os: [ubuntu-20.04]
 
     env:

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,13 @@
 {
   "extends": [
-    "config:base"
+    "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "description": "Stay compatible with older deps for brave-core",
+      "matchDepTypes": ["dependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "enabled": false
+    }
   ]
 }


### PR DESCRIPTION
The renovate bot prompts to update every dependency release, but for non-dev dependencies, we want to stay compatible with the older releases used by the brave browser, one of our downstream targets.

To reduce the noise, try to disable minor and tiny version bumps for those dependencies.

Also bumps the default config from `base` to `recommended` per validator lint.