### PR TITLE
adss doc cleanup

### DIFF
--- a/adss/CHANGELOG.md
+++ b/adss/CHANGELOG.md
@@ -1,0 +1,40 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## v0.2.2 (2023-09-14)
+
+ - <csr-id-2d1c714ae2b15f93e8c58b0aa0b7e1f88fe12f39/> Avoid `Share::from_bytes` panic when serialized share is too small
+
+## v0.2.1 (2023-07-19)
+
+ - <csr-id-8ad7543bed88e505d38d580f0195fa64bad82e31/> Update crate metadata
+   Fill out Cargo.toml to meet crates.io publication requirements.
+ - Vendor strobe-rng to allow publication.
+
+### Commit Details
+
+<csr-read-only-do-not-edit/>
+
+<details><summary>view details</summary>
+
+ * **Uncategorized**
+    - Merge pull request #275 from brave/adss-0.2.1 (f2300de)
+    - Bump version number for adss-0.2.1 (0124edc)
+    - Update crate metadata (8ad7543)
+    - Rename adss-rs to plain adss (29fbd42)
+</details>
+
+## v0.2.0 (unreleased, 2023 March 31)
+
+- Clear key material after use (zeroize)
+- Documentation fixes
+- API cleanup
+- Update deps
+
+## v0.1.3 (unreleased, circa 2021 September)
+
+- Initial version used with Web Discovery Project

--- a/adss/README.md
+++ b/adss/README.md
@@ -19,12 +19,7 @@ cargo build
 cargo test
 ```
 
-Benchmarks:
-```
-cargo bench
-```
-
-Open local copy of documentation:
+Open a local copy of the documentation:
 ```
 cargo doc --open --no-deps
 ```

--- a/adss/README.md
+++ b/adss/README.md
@@ -8,6 +8,9 @@ WARNING the libraries present in this workspace have not been audited,
 use at your own risk! This code is under active development and may
 change substantially in future versions.
 
+See the [changelog](CHANGELOG.md) for information about different
+versions.
+
 ## Quickstart
 
 Build & test:


### PR DESCRIPTION
- Add changelog with release history
- Document more of the API
- Remove obsolete `cargo bench` instructions