### PR TITLE
Use the new resolver for all crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ members = [
   "./star-wasm",
   "./ppoprf",
 ]
+resolver = "2"


### PR DESCRIPTION
Address a warning with recent (1.7x) toolchains about the dependency resolver version. Some of the crates in the shared workspace of this repository declare themselves edition="2018" while others declare edition="2021". The two editions specify different dependency resolution engines. We can use either, so pick the newer one when building as part of the workspace.

This can be removed when all crates are on the 2021 edition.