### PR TITLE
github actions: Install toolchain with rustup

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,29 @@
+name: Style
+
+on:
+  push:
+    branches:
+      - main
+  pull-request:
+    branches:
+      - main
+  schedule:
+    - cron: '19 20 3 * *'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+
+      - name: Cache
+        uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43 # v2.7.0
+
+      - name: Format
+        run: cargo fmt --all -- --check
+
+      - name: Clippy
+        uses: actions-rs/clippy-check@b5b5f21f4797c02da247df37026fcd0a5024aa4d # v1.0.7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --release --all-targets -- -D warnings -A clippy::too_many_arguments

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull-request:
+  pull_request:
     branches:
       - main
   schedule:

--- a/.github/workflows/nostd.yml
+++ b/.github/workflows/nostd.yml
@@ -25,9 +25,7 @@ jobs:
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
 
       - name: Toolchain
-        uses: dtolnay/rust-toolchain@1482605bfc5719782e1267fd0c0cc350fe7646b8 # v1
-        with:
-          toolchain: ${{matrix.rust}}
+        run: rustup default ${{matrix.rust}}
 
       - name: Cache
         uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43 # v2.7.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,14 +41,3 @@ jobs:
         with:
           command: test
           args: --release
-
-      - name: WASM pkg
-        run: |
-          curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-          cd ./star-wasm
-          make build
-
-      - name: WASM www
-        run: |
-          cd ./star-wasm/www
-          make

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,30 +25,16 @@ jobs:
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
 
       - name: Toolchain
-        run: |
-          rustup default ${{matrix.rust}}
-          rustup component add clippy rustfmt
+        run: rustup default ${{matrix.rust}}
 
       - name: Cache
         uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43 # v2.7.0
-
-      - name: Format
-        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
-        with:
-          command: fmt
-          args: -- --check
 
       - name: Build
         uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
         with:
           command: build
           args: --release --all-targets
-
-      - name: Clippy
-        uses: actions-rs/clippy-check@b5b5f21f4797c02da247df37026fcd0a5024aa4d # v1.0.7
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --release --all-targets -- -D warnings -A clippy::too_many_arguments
 
       - name: Test
         uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,12 +25,9 @@ jobs:
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
 
       - name: Toolchain
-        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
-        with:
-          profile: minimal
-          components: clippy, rustfmt
-          toolchain: ${{matrix.rust}}
-          override: true
+        run: |
+          rustup default ${{matrix.rust}}
+          rustup component add clippy rustfmt
 
       - name: Cache
         uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43 # v2.7.0

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -1,0 +1,33 @@
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+name: Tests
+
+jobs:
+  wasm:
+    runs-on: ubuntu-latest
+
+    env:
+      RUSTFLAGS: ''
+      CARGO_PROFILE_DEV_DEBUG: '0' # reduce size of target directory
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+
+      - name: Cache
+        uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43 # v2.7.0
+
+      - name: WASM pkg
+        run: |
+          curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+          cd ./star-wasm
+          make build
+
+      - name: WASM www
+        run: |
+          cd ./star-wasm/www
+          make


### PR DESCRIPTION
Replace external script reference with direct calls to `rustup` to set the target toolchain for continuous-integration tests, now that the base image supports it.

Also move lints and wasm steps to independent jobs for cleaner feedback.

NB: this removes lints and wasm testing outside the default `stable` toolchain. I think it's fine to just check those on the latest release.