### PR TITLE
ppoprf: Use a fixed server and point for eval benchmarks

### DIFF
--- a/ppoprf/benches/bench.rs
+++ b/ppoprf/benches/bench.rs
@@ -95,17 +95,17 @@ fn benchmark_server(c: &mut Criterion) {
   });
 
   c.bench_function("Server eval", |b| {
+    let server = Server::new(mds.clone()).unwrap();
+    let point = Point::from(RistrettoPoint::random(&mut OsRng));
     b.iter(|| {
-      let server = Server::new(mds.clone()).unwrap();
-      let point = Point::from(RistrettoPoint::random(&mut OsRng));
       server.eval(&point, 0, false).unwrap();
     })
   });
 
   c.bench_function("Server verifiable eval", |b| {
+    let server = Server::new(mds.clone()).unwrap();
+    let point = Point::from(RistrettoPoint::random(&mut OsRng));
     b.iter(|| {
-      let server = Server::new(mds.clone()).unwrap();
-      let point = Point::from(RistrettoPoint::random(&mut OsRng));
       server.eval(&point, 0, true).unwrap();
     })
   });


### PR DESCRIPTION
For the puncture benchmark it's important to have a fresh server state for each run, but for evaluations it doesn't really make sense to create a new private key for each evaluation. In a normal application that cost would be amortized over many evaluations.

Hoist these constants out of the benchmark loop for more relevant timing measurements.