### PR TITLE
sta-rs: MessageGenerator epoch represented by u8 slice instead of string

### DIFF
--- a/star-wasm/Cargo.toml
+++ b/star-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "star-wasm"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Rémi Berson <remi@brave.com>"]
 description = "WASM bindings for the STAR protocol"
 repository = "https://github.com/brave/sta-rs"

--- a/star-wasm/src/lib.rs
+++ b/star-wasm/src/lib.rs
@@ -42,7 +42,7 @@ pub fn create_share(measurement: &[u8], threshold: u32, epoch: &str) -> String {
   let mg = MessageGenerator::new(
     SingleMeasurement::new(measurement),
     threshold,
-    epoch,
+    epoch.as_bytes(),
   );
   let share_result = mg.share_with_local_randomness();
   if share_result.is_err() {

--- a/star/Cargo.toml
+++ b/star/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sta-rs"
-version = "0.2.2"
+version = "0.3.0"
 authors = ["Alex Davidson <coela@alxdavids.xyz>"]
 description = "Distributed Secret-Sharing for Threshold Aggregation Reporting"
 documentation = "https://docs.rs/sta-rs"

--- a/star/benches/bench.rs
+++ b/star/benches/bench.rs
@@ -18,7 +18,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
 fn benchmark_client_randomness_sampling(c: &mut Criterion) {
   c.bench_function("Client local randomness", |b| {
-    let client = client_zipf(10000, 1.03, 2, "t");
+    let client = client_zipf(10000, 1.03, 2, b"t");
     let mut out = vec![0u8; 32];
     b.iter(|| {
       client.sample_local_randomness(&mut out);
@@ -27,7 +27,7 @@ fn benchmark_client_randomness_sampling(c: &mut Criterion) {
 
   #[cfg(feature = "star2")]
   c.bench_function("Client ppoprf randomness", |b| {
-    let client = client_zipf(10000, 1.03, 2, "t");
+    let client = client_zipf(10000, 1.03, 2, b"t");
     let ppoprf_server = PPOPRFServer::new(&[b"t".to_vec()]);
     let mut out = vec![0u8; 32];
     b.iter(|| {
@@ -38,7 +38,7 @@ fn benchmark_client_randomness_sampling(c: &mut Criterion) {
 
 fn benchmark_client_triple_generation(c: &mut Criterion) {
   c.bench_function("Client generate triple (local)", |b| {
-    let mg = client_zipf(10000, 1.03, 2, "t");
+    let mg = client_zipf(10000, 1.03, 2, b"t");
     let mut rnd = [0u8; 32];
     mg.sample_local_randomness(&mut rnd);
     b.iter(|| Message::generate(&mg, &rnd, None).unwrap());
@@ -46,7 +46,7 @@ fn benchmark_client_triple_generation(c: &mut Criterion) {
 
   #[cfg(feature = "star2")]
   c.bench_function("Client generate triple (ppoprf)", |b| {
-    let mg = client_zipf(10000, 1.03, 2, "t");
+    let mg = client_zipf(10000, 1.03, 2, b"t");
     let ppoprf_server = PPOPRFServer::new(&[b"t".to_vec()]);
     let mut rnd = [0u8; 32];
     mg.sample_oprf_randomness(ppoprf_server, &mut rnd);
@@ -57,7 +57,7 @@ fn benchmark_client_triple_generation(c: &mut Criterion) {
 
   c.bench_function("Client generate triple (local, aux)", |b| {
     let random_bytes = rand::thread_rng().gen::<[u8; 32]>();
-    let mg = client_zipf(10000, 1.03, 2, "t");
+    let mg = client_zipf(10000, 1.03, 2, b"t");
     let mut rnd = [0u8; 32];
     mg.sample_local_randomness(&mut rnd);
     b.iter(|| {
@@ -69,7 +69,7 @@ fn benchmark_client_triple_generation(c: &mut Criterion) {
   #[cfg(feature = "star2")]
   c.bench_function("Client generate triple (ppoprf, aux)", |b| {
     let random_bytes = rand::thread_rng().gen::<[u8; 32]>();
-    let mg = client_zipf(10000, 1.03, 2, "t");
+    let mg = client_zipf(10000, 1.03, 2, b"t");
     let ppoprf_server = PPOPRFServer::new(&[b"t".to_vec()]);
     let mut rnd = [0u8; 32];
     mg.sample_oprf_randomness(ppoprf_server, &mut rnd);
@@ -81,7 +81,7 @@ fn benchmark_client_triple_generation(c: &mut Criterion) {
 }
 
 fn benchmark_server_retrieval(c: &mut Criterion) {
-  let mg = client_zipf(10000, 1.03, 50, "t");
+  let mg = client_zipf(10000, 1.03, 50, b"t");
   let mut rnd = [0u8; 32];
   mg.sample_local_randomness(&mut rnd);
   let messages: Vec<Message> =
@@ -128,7 +128,7 @@ fn benchmark_end_to_end(c: &mut Criterion) {
 }
 
 fn get_messages(params: &Params, epoch: &str) -> Vec<Message> {
-  let mg = client_zipf(params.n, params.s, params.threshold, epoch);
+  let mg = client_zipf(params.n, params.s, params.threshold, epoch.as_bytes());
   let mut rnd = [0u8; 32];
   if params.local {
     iter::repeat_with(|| {

--- a/star/test-utils/src/lib.rs
+++ b/star/test-utils/src/lib.rs
@@ -28,7 +28,7 @@ pub fn client_zipf(
   n: usize,
   s: f64,
   threshold: u32,
-  epoch: &str,
+  epoch: &[u8],
 ) -> MessageGenerator {
   let x = measurement_zipf(n, s);
   MessageGenerator::new(x, threshold, epoch)

--- a/star/tests/e2e.rs
+++ b/star/tests/e2e.rs
@@ -10,7 +10,11 @@ pub struct PPOPRFServer;
 
 #[test]
 fn serialize_ciphertext() {
-  let mg = MessageGenerator::new(SingleMeasurement::new(b"foobar"), 0, "epoch");
+  let mg = MessageGenerator::new(
+    SingleMeasurement::new(b"foobar"),
+    0,
+    "epoch".as_bytes(),
+  );
   let mut rnd = [0u8; 32];
   mg.sample_local_randomness(&mut rnd);
   let triple = Message::generate(&mg, &rnd, None)
@@ -21,7 +25,11 @@ fn serialize_ciphertext() {
 
 #[test]
 fn serialize_triple() {
-  let mg = MessageGenerator::new(SingleMeasurement::new(b"foobar"), 0, "epoch");
+  let mg = MessageGenerator::new(
+    SingleMeasurement::new(b"foobar"),
+    0,
+    "epoch".as_bytes(),
+  );
   let mut rnd = [0u8; 32];
   mg.sample_local_randomness(&mut rnd);
   let triple = Message::generate(&mg, &rnd, None)
@@ -32,7 +40,11 @@ fn serialize_triple() {
 
 #[test]
 fn roundtrip() {
-  let mg = MessageGenerator::new(SingleMeasurement::new(b"foobar"), 1, "epoch");
+  let mg = MessageGenerator::new(
+    SingleMeasurement::new(b"foobar"),
+    1,
+    "epoch".as_bytes(),
+  );
   let mut rnd = [0u8; 32];
   mg.sample_local_randomness(&mut rnd);
   let triple = Message::generate(&mg, &rnd, None)
@@ -116,19 +128,19 @@ fn star_no_aux_multiple_block(oprf_server: Option<PPOPRFServer>) {
       clients.push(MessageGenerator::new(
         SingleMeasurement::new(str1.as_bytes()),
         threshold,
-        epoch,
+        epoch.as_bytes(),
       ));
     } else if i % 4 == 0 {
       clients.push(MessageGenerator::new(
         SingleMeasurement::new(str2.as_bytes()),
         threshold,
-        epoch,
+        epoch.as_bytes(),
       ));
     } else {
       clients.push(MessageGenerator::new(
         SingleMeasurement::new(&[i as u8]),
         threshold,
-        epoch,
+        epoch.as_bytes(),
       ));
     }
   }
@@ -177,19 +189,19 @@ fn star_no_aux_single_block(oprf_server: Option<PPOPRFServer>) {
       clients.push(MessageGenerator::new(
         SingleMeasurement::new(str1.as_bytes()),
         threshold,
-        epoch,
+        epoch.as_bytes(),
       ));
     } else if i % 4 == 0 {
       clients.push(MessageGenerator::new(
         SingleMeasurement::new(str2.as_bytes()),
         threshold,
-        epoch,
+        epoch.as_bytes(),
       ));
     } else {
       clients.push(MessageGenerator::new(
         SingleMeasurement::new(&[i as u8]),
         threshold,
-        epoch,
+        epoch.as_bytes(),
       ));
     }
   }
@@ -239,19 +251,19 @@ fn star_with_aux_multiple_block(oprf_server: Option<PPOPRFServer>) {
       clients.push(MessageGenerator::new(
         SingleMeasurement::new(str1.as_bytes()),
         threshold,
-        epoch,
+        epoch.as_bytes(),
       ));
     } else if i % 4 == 0 {
       clients.push(MessageGenerator::new(
         SingleMeasurement::new(str2.as_bytes()),
         threshold,
-        epoch,
+        epoch.as_bytes(),
       ));
     } else {
       clients.push(MessageGenerator::new(
         SingleMeasurement::new(&[i as u8]),
         threshold,
-        epoch,
+        epoch.as_bytes(),
       ));
     }
   }
@@ -313,7 +325,7 @@ fn star_rand_with_aux_multiple_block(oprf_server: Option<PPOPRFServer>) {
   let threshold = 5;
   let epoch = "t";
   for _ in 0..254 {
-    clients.push(client_zipf(1000, 1.03, threshold, epoch));
+    clients.push(client_zipf(1000, 1.03, threshold, epoch.as_bytes()));
   }
   let agg_server = AggregationServer::new(threshold, epoch);
 


### PR DESCRIPTION
Resolves https://github.com/brave/sta-rs/issues/339