### PR TITLE
Improve aux data test

### DIFF
--- a/star/tests/e2e.rs
+++ b/star/tests/e2e.rs
@@ -1,3 +1,5 @@
+//! End-to-end tests verifying the protocol implementation
+
 use sta_rs::*;
 use star_test_utils::{client_zipf, AggregationServer};
 

--- a/star/tests/e2e.rs
+++ b/star/tests/e2e.rs
@@ -309,14 +309,17 @@ fn star_with_aux_multiple_block(oprf_server: Option<PPOPRFServer>) {
     }
 
     // Confirm the expected AssociatedData values are recovered.
-    assert!(o.aux.iter().all(|v| v.is_some()),
-      "Expected auxiliary data from all submissions!");
+    assert!(
+      o.aux.iter().all(|v| v.is_some()),
+      "Expected auxiliary data from all submissions!"
+    );
     for b in o.aux.iter().flatten() {
       let v = b.as_slice();
-      assert_eq!(v.len(), 1,
-        "Expected auxiliary data to be a single byte!");
-      assert!(v[0] < message_count,
-        "Auxiliary data should be the in range of the message count!");
+      assert_eq!(v.len(), 1, "Expected auxiliary data to be a single byte!");
+      assert!(
+        v[0] < message_count,
+        "Auxiliary data should be the in range of the message count!"
+      );
       if tag_str == str1 {
         assert!(v[0] % 3 == 0);
       } else if tag_str == str2 {

--- a/star/tests/e2e.rs
+++ b/star/tests/e2e.rs
@@ -172,7 +172,7 @@ fn star_no_aux_multiple_block(oprf_server: Option<PPOPRFServer>) {
       panic!("Unexpected tag: {}", tag_str);
     }
 
-    for b in o.aux.into_iter().flatten() {
+    if let Some(b) = o.aux.into_iter().flatten().next() {
       panic!("Unexpected auxiliary data: {:?}", b);
     }
   }
@@ -234,7 +234,7 @@ fn star_no_aux_single_block(oprf_server: Option<PPOPRFServer>) {
       panic!("Unexpected tag: {}", tag_str);
     }
 
-    for b in o.aux.into_iter().flatten() {
+    if let Some(b) = o.aux.into_iter().flatten().next() {
       panic!("Unexpected auxiliary data: {:?}", b);
     }
   }

--- a/star/tests/e2e.rs
+++ b/star/tests/e2e.rs
@@ -246,7 +246,8 @@ fn star_with_aux_multiple_block(oprf_server: Option<PPOPRFServer>) {
   let epoch = "t";
   let str1 = "hello world";
   let str2 = "goodbye sweet prince";
-  for i in 0..10 {
+  let message_count = 10;
+  for i in 0..message_count {
     if i % 3 == 0 {
       clients.push(MessageGenerator::new(
         SingleMeasurement::new(str1.as_bytes()),
@@ -303,7 +304,7 @@ fn star_with_aux_multiple_block(oprf_server: Option<PPOPRFServer>) {
         None => panic!("Expected auxiliary data!"),
         Some(b) => {
           let v = b.as_vec();
-          for i in 0..10 {
+          for i in 0..message_count {
             let aux_str = std::str::from_utf8(&v)
               .unwrap()
               .trim_end_matches(char::from(0));

--- a/star/tests/e2e.rs
+++ b/star/tests/e2e.rs
@@ -243,6 +243,7 @@ fn star_no_aux_single_block(oprf_server: Option<PPOPRFServer>) {
 }
 
 fn star_with_aux_multiple_block(oprf_server: Option<PPOPRFServer>) {
+  // Generate an assortment of client messages.
   let mut clients = Vec::new();
   let threshold = 2;
   let epoch = "t";
@@ -272,10 +273,11 @@ fn star_with_aux_multiple_block(oprf_server: Option<PPOPRFServer>) {
   }
   let agg_server = AggregationServer::new(threshold, epoch);
 
-  let mut counter = 0;
+  // Append some associated data and generate submissions.
   let messages: Vec<Message> = clients
     .into_iter()
-    .map(|mg| {
+    .zip(0..)
+    .map(|(mg, counter)| {
       let mut rnd = [0u8; 32];
       if oprf_server.is_none() {
         mg.sample_local_randomness(&mut rnd);
@@ -283,7 +285,6 @@ fn star_with_aux_multiple_block(oprf_server: Option<PPOPRFServer>) {
         #[cfg(feature = "star2")]
         mg.sample_oprf_randomness(oprf_server, &mut rnd)
       }
-      counter += 1;
       Message::generate(&mg, &rnd, Some(AssociatedData::new(&[counter; 1])))
         .unwrap()
     })
@@ -332,10 +333,10 @@ fn star_rand_with_aux_multiple_block(oprf_server: Option<PPOPRFServer>) {
   }
   let agg_server = AggregationServer::new(threshold, epoch);
 
-  let mut counter = 0;
   let messages: Vec<Message> = clients
     .into_iter()
-    .map(|mg| {
+    .zip(0..)
+    .map(|(mg, counter)| {
       let mut rnd = [0u8; 32];
       if oprf_server.is_none() {
         mg.sample_local_randomness(&mut rnd);
@@ -343,7 +344,6 @@ fn star_rand_with_aux_multiple_block(oprf_server: Option<PPOPRFServer>) {
         #[cfg(feature = "star2")]
         mg.sample_oprf_randomness(oprf_server, &mut rnd);
       }
-      counter += 1;
       Message::generate(&mg, &rnd, Some(AssociatedData::new(&[counter; 4])))
         .unwrap()
     })

--- a/star/tests/e2e.rs
+++ b/star/tests/e2e.rs
@@ -1,5 +1,5 @@
 use sta_rs::*;
-use star_test_utils::*;
+use star_test_utils::{client_zipf, AggregationServer};
 
 #[cfg(feature = "star2")]
 use ppoprf::ppoprf::{end_to_end_evaluation, Server as PPOPRFServer};

--- a/star/tests/e2e.rs
+++ b/star/tests/e2e.rs
@@ -268,7 +268,7 @@ fn star_with_aux_multiple_block(oprf_server: Option<PPOPRFServer>) {
     } else {
       // Unique measurements which will not meet threshold.
       clients.push(MessageGenerator::new(
-        SingleMeasurement::new(&[i as u8]),
+        SingleMeasurement::new(&[i]),
         threshold,
         epoch.as_bytes(),
       ));

--- a/star/tests/e2e.rs
+++ b/star/tests/e2e.rs
@@ -271,7 +271,6 @@ fn star_with_aux_multiple_block(oprf_server: Option<PPOPRFServer>) {
       ));
     }
   }
-  let agg_server = AggregationServer::new(threshold, epoch);
 
   // Append some associated data and generate submissions.
   let messages: Vec<Message> = clients
@@ -289,7 +288,10 @@ fn star_with_aux_multiple_block(oprf_server: Option<PPOPRFServer>) {
         .unwrap()
     })
     .collect();
-  let outputs = agg_server.retrieve_outputs(&messages[..]);
+
+  // Aggregate and recover messages meeting threshold.
+  let agg_server = AggregationServer::new(threshold, epoch);
+  let outputs = agg_server.retrieve_outputs(&messages);
   for o in outputs {
     let tag_str = std::str::from_utf8(o.x.as_slice())
       .unwrap()


### PR DESCRIPTION
Minor clean-up of the end-to-end test module
- Adjust code to address recent clippy warnings with Rust 1.74.
- Rewrite the aux data validation in `star_with_aux_multiple_block` to better verify the recovered values.
- use `zip(0..)` for functional-style enumeration instead of an explicit mutable counter.