### PR TITLE
github actions: remove rust-cache

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,9 +16,6 @@ jobs:
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-      - name: Cache
-        uses: Swatinem/rust-cache@a22603398250b864f7190077025cf752307154dc # v2.7.2
-
       - name: Format
         run: cargo fmt --all -- --check
 

--- a/.github/workflows/nostd.yml
+++ b/.github/workflows/nostd.yml
@@ -27,9 +27,6 @@ jobs:
       - name: Toolchain
         run: rustup default ${{matrix.rust}}
 
-      - name: Cache
-        uses: Swatinem/rust-cache@a22603398250b864f7190077025cf752307154dc # v2.7.2
-
       - name: Check
         run: cargo check --no-default-features --all-targets
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,9 +27,6 @@ jobs:
       - name: Toolchain
         run: rustup default ${{matrix.rust}}
 
-      - name: Cache
-        uses: Swatinem/rust-cache@a22603398250b864f7190077025cf752307154dc # v2.7.2
-
       - name: Build
         uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
         with:

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -18,9 +18,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-      - name: Cache
-        uses: Swatinem/rust-cache@a22603398250b864f7190077025cf752307154dc # v2.7.2
-
       - name: WASM pkg
         run: |
           curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh


### PR DESCRIPTION
Now that we're trying to review changes to github action scripts, it may not be worthwhile to use the cache. Experiment with removing it to see how that affects ci performance.