### PR TITLE
Rump MSRV to 1.74.1

### DIFF
--- a/.github/workflows/nostd.yml
+++ b/.github/workflows/nostd.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        rust: [1.71.1, stable]
+        rust: [1.74.1, stable]
         os: [ubuntu-20.04]
 
     env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        rust: [1.71.1, stable]
+        rust: [1.74.1, stable]
         os: [ubuntu-20.04]
 
     env:


### PR DESCRIPTION
Raise the minimum-supported rust version to 1.74, which is only three months old. The library itself could still build under 1.64.0, but example and benchmark harnesses require this and since it's old enough for the brave-core downstream it seems easier to drop active testing on older versions than remove the benchmark harness and example code.