### PR TITLE
Remove unused cbindgen cfg_attr

### DIFF
--- a/adss/src/lib.rs
+++ b/adss/src/lib.rs
@@ -110,7 +110,6 @@ impl From<AccessStructure> for Sharks {
 /// "random coins" which provide strong but possibly non-uniform
 /// entropy and an optional STROBE transcript which can include
 /// extra data which will be authenticated.
-#[cfg_attr(not(feature = "cbindgen"), repr(C))]
 #[allow(non_snake_case)]
 #[derive(Clone, ZeroizeOnDrop)]
 pub struct Commune {


### PR DESCRIPTION
This looks like it was used for the convenience of low-level bindings, but our current bindings are higher level, and this is unused.

Addresses a warning about the reference to an undeclared feature in rust 1.80.0.